### PR TITLE
Change script CDN URL's to https

### DIFF
--- a/examples/network/data/dotLanguage/dotEdgeStyles.html
+++ b/examples/network/data/dotLanguage/dotEdgeStyles.html
@@ -3,7 +3,7 @@
 <head>
   <title>Network | DOT edge styles</title>
 
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
   <script src="../../../../dist/vis-network.min.js"></script>
   <link href="../../../../dist/vis-network.min.css" rel="stylesheet" type="text/css" />
 

--- a/examples/network/data/dotLanguage/dotPlayground.html
+++ b/examples/network/data/dotLanguage/dotPlayground.html
@@ -3,7 +3,7 @@
 <head>
   <title>Network | DOT language playground</title>
 
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
   <script src="../../../../dist/vis-network.min.js"></script>
   <link href="../../../../dist/vis-network.min.css" rel="stylesheet" type="text/css" />
 


### PR DESCRIPTION
Githup is all https causing mixed content from CDN's to fail loading with the below message. All CDN URL's used in examples should be changed to https.

Blocked loading mixed active content “http://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js”