### PR TITLE
visjs-network#43: Edge labels disappear when cluster is opened

### DIFF
--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -141,7 +141,7 @@ class Edge {
     // Only copy label if it's a legal value.
     if (ComponentUtil.isValidLabel(newOptions.label)) {
       parentOptions.label = newOptions.label;
-    } else {
+    } else if (!ComponentUtil.isValidLabel(parentOptions.label)) {
       parentOptions.label = undefined;
     }
 

--- a/test/Network.test.js
+++ b/test/Network.test.js
@@ -85,13 +85,13 @@ function createSampleNetwork(options) {
       {id: 14, label: '14'},
   ]);
   var edges = new DataSet([
-      {from: 1, to: 2},
-      {from: 2, to: 3},
-      {from: 3, to: 4},
-      {from: 11, to: 12},
-      {from: 12, to: 13},
-      {from: 13, to: 14},
-  ]);    
+    { from: 1, to: 2, label: '1 to 2' },
+    { from: 2, to: 3, label: '2 to 3' },
+    { from: 3, to: 4, label: '3 to 4' },
+    { from: 11, to: 12, label: '11 to 12' },
+    { from: 12, to: 13, label: '12 to 13' },
+    { from: 13, to: 14, label: '13 to 14' }
+  ]);
 
   // create a network
   var container = document.getElementById('mynetwork');
@@ -175,6 +175,21 @@ function assertNumEdges(network, expectedPresent, expectedVisible) {
   assert.equal(network.body.edgeIndices.length, expectedVisible, "Number of visible edges does not match");
 };
 
+function assertEdgeLabels(network, originalEdgesDataSet, assertMessagePrefix) {
+  let originalIds =  originalEdgesDataSet.getIds()
+
+  for (let index = 0; index < originalIds.length; index++) {
+    let id = originalIds[index]
+    let expectedOriginalEdge = originalEdgesDataSet.get(id)
+    let currentNetworkEdge = network.body.edges[id]
+
+    assert.equal(
+      currentNetworkEdge.options.label,
+      expectedOriginalEdge.label,
+      assertMessagePrefix + ' - current edge labels do not match the original edge labels'
+    )
+  }
+}
 
 /**
  * Check if the font options haven't changed.
@@ -1103,6 +1118,7 @@ describe('Clustering', function () {
   it('properly opens 1-level clusters', function () {
     var [network, data, numNodes, numEdges] = createSampleNetwork();
 
+    assertEdgeLabels(network, data.edges, "New sample network");
     // Pedantic: make a cluster of everything
     clusterTo(network, 'c1', [1,2,3,4,11, 12, 13, 14]);
     // c1(14-13-12-11 1-2-3-4)
@@ -1114,6 +1130,7 @@ describe('Clustering', function () {
     numNodes -= 1;
     assertNumNodes(network, numNodes, numNodes); // Expecting same as original
     assertNumEdges(network, numEdges, numEdges);
+    assertEdgeLabels(network, data.edges, "c1(14-13-12-11 1-2-3-4) cluster opened");
 
     // One external connection
     [network, data, numNodes, numEdges] = createSampleNetwork();
@@ -1128,6 +1145,7 @@ describe('Clustering', function () {
     network.clustering.openCluster('c1', {});
     assertNumNodes(network, numNodes, numNodes); // Expecting same as original
     assertNumEdges(network, numEdges, numEdges);
+    assertEdgeLabels(network, data.edges, "c1(3-4) cluster opened");
 
     // One external connection to cluster
     clusterTo(network, 'c1', [1,2]);  
@@ -1145,10 +1163,12 @@ describe('Clustering', function () {
     data.edges.update({
       from: 1,
       to: 11,
+      label: "1 to 11"
     });
     numEdges += 1;
     assertNumNodes(network, numNodes, numNodes);
     assertNumEdges(network, numEdges, numEdges);
+    assertEdgeLabels(network, data.edges, "c1(1-2) c2(3-4) c1 cluster opened");
 
     clusterTo(network, 'c1', [1,2]);  
     // 14-13-12-11-c1(-1-2-)-3-4
@@ -1172,6 +1192,7 @@ describe('Clustering', function () {
     // 14-13-c3(-12-11-)-1-2-c2(-3-4)
     assertNumNodes(network, numNodes, numNodes - 4);
     assertNumEdges(network, numEdges, numEdges - 5);
+    assertEdgeLabels(network, data.edges, "14-13-c3(-12-11-)-1-2-c2(-3-4) c1 cluster opened");
   });
 
 
@@ -1181,7 +1202,9 @@ describe('Clustering', function () {
    */
   it('properly opens clustered clusters', function () {
     var [network, data, numNodes, numEdges] = createSampleNetwork();
-		data.edges.update({from: 1, to: 11,});
+    assertEdgeLabels(network, data.edges, "New sample network");
+
+    data.edges.update({ from: 1, to: 11, label: "1 to 11" })
     numEdges += 1;
 		clusterTo(network, 'c1', [3,4]);	
 		clusterTo(network, 'c2', [2,'c1']);	
@@ -1206,13 +1229,14 @@ describe('Clustering', function () {
     numEdges -= 1;
     assertNumNodes(network, numNodes, numNodes - 5);
     assertNumEdges(network, numEdges, numEdges - 5);
+    assertEdgeLabels(network, data.edges, "c2 clustered cluster opened")
 
     //
     // Same, with one external connection to cluster
     //
     var [network, data, numNodes, numEdges] = createSampleNetwork();
-		data.edges.update({from: 1, to: 11,});
-		data.edges.update({from: 2, to: 12,});
+		data.edges.update({from: 1, to: 11, label: "1 to 11"});
+		data.edges.update({from: 2, to: 12, label: "2 to 12"});
     numEdges += 2;
     // 14-13-12-11-1-2-3-4
     //        |------|
@@ -1261,6 +1285,7 @@ describe('Clustering', function () {
     numEdges -= 2;
     assertNumNodes(network, numNodes, 4);  // visibility doesn't change, cluster opened within cluster
     assertNumEdges(network, numEdges, 3);  // (I)
+    assertEdgeLabels(network, data.edges, "One external connection c2 middle clustered cluster opened");
 
     // Open the top cluster
     network.clustering.openCluster('c3', {});
@@ -1277,6 +1302,7 @@ describe('Clustering', function () {
     numEdges  = 12;
     assertNumNodes(network, numNodes, 6);  // visibility doesn't change, cluster opened within cluster
     assertNumEdges(network, numEdges, 6);  // (II) link 2-12 visible again
+    assertEdgeLabels(network, data.edges, "One external connection c3 top clustered cluster opened");
   });
 });  // Clustering
 


### PR DESCRIPTION
This is an original contribution from @channeladam: https://github.com/visjs-community/visjs-network/pull/43

> Fixes [visjs-network#42](https://github.com/visjs-community/visjs-network/issues/42)
> Automated tests updated to prove the solution.

partially fixes #7