### PR TITLE
chore(examples): add dot language examples to overview

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -63,6 +63,11 @@
         <a class='exampleLink' href="network/events/physicsEvents.html">physics events, stabilization etc.</a><br />
         <a class='exampleLink' href="network/events/renderEvents.html">rendering events, use to draw custom items on the canvas.</a><br />
 
+        <h3>dynamic data - dot language</h3>
+        <a class='exampleLink' href="examples/network/data/dotLanguage/dotEdgeStyles.html">DOT edge styles</a><br />
+        <a class='exampleLink' href="examples/network/data/dotLanguage/dotLanguage.html">DOT Language</a><br />
+        <a class='exampleLink' href="examples/network/data/dotLanguage/dotPlayground.html">DOT language playground</a><br />
+
         <h3>dynamic data</h3>
         <a class='exampleLink' href="network/data/datasets.html">dataset for dynamic data</a><br />
         <a class='exampleLink' href="network/data/dynamicData.html">dynamic data, playground</a><br />


### PR DESCRIPTION
adds missing dot language examples to the example overview