### PR TITLE
vis#4026: remove edge tooltip when hovering a node

### DIFF
--- a/lib/network/modules/InteractionHandler.js
+++ b/lib/network/modules/InteractionHandler.js
@@ -619,6 +619,7 @@ class InteractionHandler {
       for (let i = 0; i < nodeIndices.length; i++) {
         node = nodes[nodeIndices[i]];
         if (node.isOverlappingWith(pointerObj) === true) {
+          nodeUnderCursor = true;
           if (node.getTitle() !== undefined) {
             overlappingNodes.push(nodeIndices[i]);
           }


### PR DESCRIPTION
This is an original contribution from @Gelio: https://github.com/almende/vis/pull/4026
This was also copies to visjs-netwoek: 
https://github.com/visjs-community/visjs-network/pull/26

partially fixes #7

---

When supplying an edge tooltip (`title`) without providing a node tooltip (`title`), the edge's tooltip will be displayed even though the node is hovered and the tooltip is in the background.

![screenshot from 2018-07-05 16-37-43](https://user-images.githubusercontent.com/889383/42329854-04539662-8072-11e8-9a96-d2018d1b45a7.png)

This PR fixes that behavior.

---

How to reproduce:
Take a look at https://almende.github.io/vis/examples/network/data/scalingNodesEdgesLabels.html

- Hover over an edge until the tooltip appears
- Move the mouse towards a node (following the edge)
- Move the mouse into the node (following the edge)

The tooltip does not disappear, even though the edge is technically not visible now since the node is on top of it.

---

## before
![vis-pr-4026-before](https://user-images.githubusercontent.com/2119400/45047019-ba924d80-b02c-11e8-86d7-6cf4e61a03ae.gif)

## after
![vis-pr-4026-after](https://user-images.githubusercontent.com/2119400/45047034-c4b44c00-b02c-11e8-86ac-23bb40349efb.gif)