### PR TITLE
vis#3771: add new events to control drag and drop of nodes

### DIFF
--- a/docs/network/index.html
+++ b/docs/network/index.html
@@ -1414,6 +1414,27 @@ Thus, to get the topmost item, get the value at index 0.
                 <td>same as <code>click</code>.</td>
                 <td>Fired when the drag has finished.</td>
             </tr>
+            <tr><td id="event_controlNodeDragging">controlNodeDragging</td>
+                <td>Object</td>
+                <td>Fired when dragging control node. Control Edge is edge that is being dragged and contains ids of 'from' and 'to' nodes. If control node is not dragged over another node, 'to' field is undefined. Passes an object with properties structured as:
+
+<pre class="prettyprint lang-js">{
+    nodes: [Array of selected nodeIds],
+    edges: [Array of selected edgeIds],
+    event: [Object] original click event,
+    pointer: {
+        DOM: {x:pointer_x, y:pointer_y},
+        canvas: {x:canvas_x, y:canvas_y}
+    },    
+    controlEdge: {from:from_node_id, to:to_node_id}
+}
+</pre>
+                </td>
+            </tr>
+            <tr><td id="event_controlNodeDragEnd">controlNodeDragEnd</td>
+                <td>same as <code>controlNodeDragging</code>.</td>
+                <td>Fired when the control node drag has finished.</td>
+            </tr>
             <tr><td id="event_hoverNode">hoverNode</td>
                 <td><code>{node: nodeId}</code></td>
                 <td>Fired if the option <code>interaction:{hover:true}</code> is enabled and the mouse hovers over a node.</td>

--- a/examples/network/events/interactionEvents.html
+++ b/examples/network/events/interactionEvents.html
@@ -87,6 +87,15 @@
         console.log('dragEnd Event:', params);
         console.log('dragEnd event, getNodeAt returns: ' + this.getNodeAt(params.pointer.DOM));
     });
+    network.on("controlNodeDragging", function (params) {
+        params.event = "[original event]";
+        document.getElementById('eventSpan').innerHTML = '<h2>control node dragging event:</h2>' + JSON.stringify(params, null, 4);
+    });
+    network.on("controlNodeDragEnd", function (params) {
+        params.event = "[original event]";
+        document.getElementById('eventSpan').innerHTML = '<h2>control node drag end event:</h2>' + JSON.stringify(params, null, 4);
+        console.log('controlNodeDragEnd Event:', params);
+    });
     network.on("zoom", function (params) {
         document.getElementById('eventSpan').innerHTML = '<h2>zoom event:</h2>' + JSON.stringify(params, null, 4);
     });

--- a/lib/network/modules/ManipulationSystem.js
+++ b/lib/network/modules/ManipulationSystem.js
@@ -1060,6 +1060,28 @@ class ManipulationSystem {
    */
   _dragControlNode(event) {
     let pointer = this.body.functions.getPointer(event.center);
+
+    var pointerObj = this.selectionHandler._pointerToPositionObject(pointer);
+    // remember the edge id
+    var connectFromId = undefined;
+    if (this.temporaryIds.edges[0] !== undefined) {
+      connectFromId = this.body.edges[this.temporaryIds.edges[0]].fromId;
+    }
+
+    // get the overlapping node but NOT the temporary node;
+    var overlappingNodeIds = this.selectionHandler._getAllNodesOverlappingWith(pointerObj);
+    var node = undefined;
+    for (var i = overlappingNodeIds.length - 1; i >= 0; i--) {
+      // if the node id is NOT a temporary node, accept the node.
+      if (this.temporaryIds.nodes.indexOf(overlappingNodeIds[i]) === -1) {
+        node = this.body.nodes[overlappingNodeIds[i]];
+        break;
+      }
+    }
+    
+    event.controlEdge = { from: connectFromId, to: node ? node.id : undefined };
+    this.selectionHandler._generateClickEvent('controlNodeDragging', event, pointer);
+
     if (this.temporaryIds.nodes[0] !== undefined) {
       let targetNode = this.body.nodes[this.temporaryIds.nodes[0]]; // there is only one temp node in the add edge mode.
       targetNode.x = this.canvas._XconvertDOMtoCanvas(pointer.x);
@@ -1116,6 +1138,8 @@ class ManipulationSystem {
       }
     }
 
+    event.controlEdge = { from: connectFromId, to: node ? node.id : undefined };
+    this.selectionHandler._generateClickEvent('controlNodeDragEnd', event, pointer);
 
     // No need to do _generateclickevent('dragEnd') here, the regular dragEnd event fires.
     this.body.emitter.emit('_redraw');

--- a/lib/network/modules/SelectionHandler.js
+++ b/lib/network/modules/SelectionHandler.js
@@ -148,6 +148,10 @@ class SelectionHandler {
       properties.items = this.getClickedItems(pointer);
     }
 
+    if (event.controlEdge !== undefined) {
+      properties.controlEdge = event.controlEdge;
+    }
+
     this.body.emitter.emit(eventType, properties);
   }
 


### PR DESCRIPTION
This is an original contribution from @vasa93: https://github.com/almende/vis/pull/3771
This was also copies to visjs-network: 
https://github.com/visjs-community/visjs-network/pull/34

partially fixes #7

---

We need notification on control node dragging and drag end for Vis **Network**. We need this so we can introduce some constraints for connecting nodes, and we need to do that proactively by changing cursor to 'not-allowed' when connecting is not allowed.

To solve this we introduced two new events 'controlNodeDragging' and 'controlNodeDragEnd', that notify us about control node state. These events are generated inside _dragControlNode and _finishConnect functions respectively. With this implemented, we can now change cursor over control node by checking constraints at the moment when event occurs. This looks as in attached image.

![image](https://user-images.githubusercontent.com/18378954/34942739-0d82a19c-f9f9-11e7-914c-7a4799e1719b.png)