### PR TITLE
visjs-network#40: fix type of zoomSpeed

### DIFF
--- a/lib/network/options.js
+++ b/lib/network/options.js
@@ -574,7 +574,7 @@ let configureOptions = {
     hoverConnectedEdges: true,
     tooltipDelay: [300, 0, 1000, 25],
     zoomView: true,
-    zoomSpeed: 1
+    zoomSpeed: [1, 1, 1, 1]
   },
   manipulation: {
     enabled: false,


### PR DESCRIPTION
This is an original contribution from @geminoa: https://github.com/visjs-community/visjs-network/pull/40

this is an addition to https://github.com/almende/vis/pull/3657 that is already merge here.

part of #7
