### PR TITLE
visjs-network#45: correctly set invalid labels to undefined

### DIFF
--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -43,7 +43,7 @@ class Label {
       this.labelDirty = true;
     } else {
       // Bad label! Change the option value to prevent bad stuff happening
-      options.label = '';
+      options.label = undefined
     }
 
     if (options.font !== undefined && options.font !== null) { // font options can be deleted at various levels

--- a/test/Label.test.js
+++ b/test/Label.test.js
@@ -18,7 +18,7 @@ import canvasMockify from './canvas-mock';
 import Label from '../lib/network/modules/components/shared/Label';
 import NodesHandler from '../lib/network/modules/NodesHandler';
 import Network from '../lib/network/Network';
-
+import ComponentUtil from '../lib/network/modules/components/shared/ComponentUtil';
 
 /**************************************************************
  * Dummy class definitions for minimal required functionality.
@@ -1619,6 +1619,45 @@ describe('Shorthand Font Options', function() {
     var options = {};
     var network = new Network(container, data, options);
 
-    done();
-  });
-});
+    done()
+  })
+
+  describe('visible function', function() {
+    it('correctly determines label is not visible when label is invalid', function(done) {
+      var invalidLabel = ''
+      assert(
+        !ComponentUtil.isValidLabel(invalidLabel),
+        'An empty string should be identified as an invalid label'
+      )
+
+      var body = {
+        view: {
+          scale: 1
+        }
+      }
+
+      var options = {
+        label: invalidLabel,
+        font: {
+          size: 12
+        },
+        scaling: {
+          label: {
+            drawThreshold: 1
+          }
+        }
+      }
+
+      var label = new Label(body, options)
+      label.size.width = 1
+      label.size.height = 1
+
+      assert(
+        !label.visible(),
+        'Label should not be visible because the label text is invalid'
+      )
+
+      done()
+    })
+  })
+})


### PR DESCRIPTION
This is an original contribution from @channeladam: https://github.com/visjs-community/visjs-network/pull/45

fixes https://github.com/visjs-community/visjs-network/issues/44

part of #7