### PR TITLE
visjs-network#68: hidden edge bug

### DIFF
--- a/examples/network/tests/hidden_edge_test.html
+++ b/examples/network/tests/hidden_edge_test.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>JS Bin</title>
-    <script type="text/javascript" src="../dist/vis.js"></script> <!-- network handling framework -->
-    <link href="../dist/vis.css" rel="stylesheet" type="text/css"/>
+    <script type="text/javascript" src="../../../dist/vis-network.min.js"></script>
+    <link href="../../../dist/vis-network.min.css" rel="stylesheet" type="text/css" />
     <style type="text/css">
         #network{
             width: 1200px;

--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -62,6 +62,12 @@ class Edge {
     if (!options) {
       return;
     }
+	
+	// record original value of this.options.hidden (coerced to true or false)
+	var old_hidden = this.options.hidden;
+	if (old_hidden === undefined || old_hidden === null) {
+		old_hidden = false;
+	}
 
     Edge.parseOptions(this.options, options, true, this.globalOptions);
 
@@ -95,7 +101,19 @@ class Edge {
     // A node is connected when it has a from and to node that both exist in the network.body.nodes.
     this.connect();
 
-    if (options.hidden !== undefined || options.physics !== undefined) {
+    // record new value of this.options.hidden (coerced to true or false)
+    var new_hidden = this.options.hidden;
+    if (new_hidden === undefined || new_hidden === null) {
+      new_hidden = false;
+    }
+
+    // only flag dataChanged if hidden has changed
+    if (new_hidden != old_hidden) {
+      dataChanged = true;
+    }
+
+    // there might be a similar problem with physics, but a bug has not been reported	
+    if (options.physics !== undefined) {
       dataChanged = true;
     }
 

--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -62,12 +62,13 @@ class Edge {
     if (!options) {
       return;
     }
-	
-	// record original value of this.options.hidden (coerced to true or false)
-	var old_hidden = this.options.hidden;
-	if (old_hidden === undefined || old_hidden === null) {
-		old_hidden = false;
-	}
+
+    // record old value of this.options.hidden
+    let oldHidden = this.options.hidden
+
+    if (oldHidden === undefined || oldHidden === null) {
+      oldHidden = false
+    }
 
     Edge.parseOptions(this.options, options, true, this.globalOptions);
 
@@ -101,15 +102,13 @@ class Edge {
     // A node is connected when it has a from and to node that both exist in the network.body.nodes.
     this.connect();
 
-    // record new value of this.options.hidden (coerced to true or false)
-    var new_hidden = this.options.hidden;
-    if (new_hidden === undefined || new_hidden === null) {
-      new_hidden = false;
-    }
+    let newHidden = this.options.hidden
 
-    // only flag dataChanged if hidden has changed
-    if (new_hidden != old_hidden) {
-      dataChanged = true;
+    if (newHidden === undefined || newHidden === null) {
+      newHidden = false
+    }
+    if (newHidden != oldHidden || options.physics !== undefined) {
+      dataChanged = true
     }
 
     // there might be a similar problem with physics, but a bug has not been reported	

--- a/test/hidden_edge_test.html
+++ b/test/hidden_edge_test.html
@@ -16,7 +16,7 @@
 <body>
 
 <div id="explanation">
-<h4>Click on node 3. Drag it to the right. Release the mouse. Then hover over it. The graph will reset (it shouldn't).</h4>
+<h4>Click on node 3. Drag it to the right. Release the mouse. Then hover over it. The graph will reset (it shouldn't). This addresses visjs-network issue #67</h4>
 </div>
 
 <div id="network"></div>

--- a/test/hidden_edge_test.html
+++ b/test/hidden_edge_test.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>JS Bin</title>
+    <script type="text/javascript" src="../dist/vis.js"></script> <!-- network handling framework -->
+    <link href="../dist/vis.css" rel="stylesheet" type="text/css"/>
+    <style type="text/css">
+        #network{
+            width: 1200px;
+            height: 800px;
+            border: 1px solid lightgray;
+        }
+    </style>
+</head>
+<body>
+
+<div id="explanation">
+<h4>Click on node 3. Drag it to the right. Release the mouse. Then hover over it. The graph will reset (it shouldn't).</h4>
+</div>
+
+<div id="network"></div>
+
+<script>
+var nodes = null;
+var edges = null;
+var network = null;
+//
+nodes = [];
+edges = [];
+nodes.push({
+    id: 1,
+    label: 'node 1'
+});
+nodes.push({
+    id: 2,
+    label: 'node 2'
+});
+nodes.push({
+    id: 3,
+    label: 'node 3'
+});
+edges.push({
+    from: 1,
+    to: 1,
+    label: 'Edge label 1'
+	,
+    hidden: true
+});
+edges.push({
+    from: 2,
+    to: 3,
+    label: 'Edge label 2'
+	,
+    hidden: false
+});
+
+// create a network
+var container = document.getElementById('network');
+var data = {
+    nodes: nodes,
+    edges: edges
+};
+var options = {
+    nodes: {
+        scaling: {
+            min: 16,
+            max: 32
+        }
+    },
+
+    width: "100%",
+    height: "100%",
+    interaction: {
+        hover: true
+    },
+    layout: {
+        hierarchical: {
+            enabled: true,
+            levelSeparation: 160,
+            nodeSpacing: 10,
+            blockShifting: true,
+            edgeMinimization: true,
+            sortMethod: "directed"
+        }
+    },
+    edges: {
+        smooth: false
+    }
+};
+
+network = new vis.Network(container, data, options);
+
+network.on('hoverEdge', function(e) {
+    this.body.data.edges.update({
+        id: e.edge,
+        font: {
+            size: 14
+        }
+    });
+});
+
+network.on('blurEdge', function(e) {
+    this.body.data.edges.update({
+        id: e.edge,
+        font: {
+            size: 0
+        }
+    });
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
This is an original contribution from @DarylMcCullough: https://github.com/visjs-community/visjs-network/pull/68

part of #7

---

Fixes issue #67 "Network - does updating an edge cause it to reset automatically in Hierarchical view".

There is an example of the buggy behavior in test/hidden_edge_test.html. To see the bug:

Click on node 3.
Drag it to the right.
Release the mouse.
Then hover over node 3 (or any other node or edge).
The graph will reset (it shouldn't).
The only change is to the file Edge.js in lib/network/modules/components. Rebuild using "yarn" and "yarn build" and then retry the example hidden_edge_test.html