### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: node_js
+
+os: linux
+
+node_js: node
+
+before_deploy:
+  - npm version $(node -p 'require("./package.json").version')-next.$(git rev-list --count master).$(git rev-parse HEAD)
+deploy:
+  provider: npm
+  email: TODO: whoever is going to be responsible for this
+  skip_cleanup: true
+  tag: next
+  api_key:
+    secure: TODO: ecrypted npmjs access token
+  on:
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ before_deploy:
   - npm version $(node -p 'require("./package.json").version')-next.$(git rev-list --count master).$(git rev-parse HEAD)
 deploy:
   provider: npm
-  email: TODO: whoever is going to be responsible for this
+  email: tom.vycital@gmail.com
   skip_cleanup: true
   tag: next
   api_key:
-    secure: TODO: ecrypted npmjs access token
+    secure: wOZWHx9Ylrm9CNGKAECNCtKRbk0cjODFZCDpL9AhOlbIO+Ktr8WokijTS+nuc25RoKAWaKR6XxBzYvHhnsuRjt2/GuejYMzqbk2oarjao86vYXzfSlLX2eoaGibzqi0sFQ7N4HPKJwpr4ITrRDm/ilEm02qrE36eFb32XFT0utkbhONAPNN2y4Ic13ibKKDy14RNCBWtqmgiOPbDTd6K+eQ5fBGg2xLp3SLA00AT492zcYD8sMeoakUCrYXzQ/tLTaoaeugCwyN3XMji97m2jOJfE2XixExM35xAcnaK06zsNg2d6IqkQ39Mv5EvQfv1/Yvr4nsDsNRImYMxM4OnPENyVmKNhPOTjT+5m1cZmL1wlTFHXi6+egtcgLt9uq+Ft3sVmnGRtpmSWvtEQOY4dFlUEIQy90DlIygeKM99HF1EZsQPqf3MM+hANqBTCw/TdSElLRIdT/jKi00NFAEF5cqdwO5LOL9btYVMvVq/1Sma2sXyLmi+kqk4AW7Fh8fn8WHARi+ZHjITG+D356uDD+rsea46nwqWuy3oZ8JYnOclOtXw6rTFKAw1w/qwXJv3gr67AZbYeNrAJvB7WhoBUKUFhM73NmPQfW2t4CxkWXukLbXKqP/hDP98lMPRGcDDKCjJ6in9aINuu10Z6+L9MBxbwgRvRwKzPOEDibXidZs=
   on:
     branch: master

--- a/package-lock.json
+++ b/package-lock.json
@@ -1042,18 +1042,6 @@
         "@types/json-schema": "^7.0.3",
         "@typescript-eslint/typescript-estree": "1.13.0",
         "eslint-scope": "^4.0.0"
-      },
-      "dependencies": {
-        "eslint-scope": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-          "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        }
       }
     },
     "@typescript-eslint/parser": {
@@ -1825,9 +1813,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000985",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000985.tgz",
-      "integrity": "sha512-1ngiwkgqAYPG0JSSUp3PUDGPKKY59EK7NrGGX+VOxaKCNzRbNc7uXMny+c3VJfZxtoK3wSImTvG9T9sXiTw2+w==",
+      "version": "1.0.30000986",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000986.tgz",
+      "integrity": "sha512-pM+LnkoAX0+QnIH3tpW5EnkmfpEoqOD8FAcoBvsl3Xh6DXkgctiCxeCbXphP/k3XJtJzm+zOAJbi6U6IVkpWZQ==",
       "dev": true
     },
     "caseless": {
@@ -2363,9 +2351,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.199",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.199.tgz",
-      "integrity": "sha512-gachlDdHSK47s0N2e58GH9HMC6Z4ip0SfmYUa5iEbE50AKaOUXysaJnXMfKj0xB245jWbYcyFSH+th3rqsF8hA==",
+      "version": "1.3.202",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.202.tgz",
+      "integrity": "sha512-oJHvNNYM3Y9mJfiujbFQxRa0v7mzrc6Pv76fq6A4Dd6MxbfiVGhmgXtIeMBloTF8crmlJ1rXQW95VS4Zp/9ZSg==",
       "dev": true
     },
     "emoji-regex": {
@@ -2517,6 +2505,16 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
+        "eslint-scope": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
         "glob-parent": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
@@ -2553,9 +2551,9 @@
       }
     },
     "eslint-scope": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -6209,9 +6207,9 @@
       "dev": true
     },
     "tsutils": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.0.tgz",
-      "integrity": "sha512-SmzGbB0l+8I0QwsPgjooFRaRvHLBLNYM8SeQ0k6rtNDru5sCGeLJcZdwilNndN+GysuFjF5EIYgN8GfFG6UeUw==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.1.tgz",
+      "integrity": "sha512-kiuZzD1uUA5DxGj/uxbde+ymp6VVdAxdzOIlAFbYKrPyla8/uiJ9JLBm1QsPhOm4Muj0/+cWEDP99yoCUcSl6Q==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
@@ -6440,18 +6438,18 @@
       }
     },
     "vis-util": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vis-util/-/vis-util-1.1.1.tgz",
-      "integrity": "sha512-2uAJ+XbeQs4mXoeM59KkOJCGc4loM737yYdohm1EMOOPkMJLWP9G/aBUmi4Y2F9alE1Og1D938xeWm91x7RLcw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vis-util/-/vis-util-1.1.2.tgz",
+      "integrity": "sha512-c9pF7bI7uCrwB+69F86riFA97JPBbhRt8Kg4KwubT/ffPLS/eMjb/oN5tr8rjsK0cfPwqQXcKKcwTyX9kJoc6A==",
       "requires": {
         "moment": "^2.24.0",
-        "vis-uuid": "^1.0.2"
+        "vis-uuid": "^1.1.3"
       }
     },
     "vis-uuid": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vis-uuid/-/vis-uuid-1.1.1.tgz",
-      "integrity": "sha512-5V9YhMq7MRd4sa3knm+UrMq5N44kYyaOTdgbbql8an+ZgHsNWZ6OhftaC9Bm4kmc1RtAPrjH5tgIs1LjEmd4vQ=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vis-uuid/-/vis-uuid-1.1.3.tgz",
+      "integrity": "sha512-2B6XdY1bkzbUh+TugmnAaFa61KO9R5pzBzIuFIm8a9FrkbxIdSmQXV+FbfkL8QunkQV/bT0JDLQ2puqCS2+0Og=="
     },
     "w3c-hr-time": {
       "version": "1.0.1",


### PR DESCRIPTION
I played around a bit with Travis in one of my projects and thought it would be neat to have it here.

- Runs `npm test` on each commit and pull request.
- On each commit to (merge into) master it publishes to npmjs (uses `@next` tag and each version includes commit hash, `@latest` and normal versions are still handled manually to prevent random errors in production).

Of course someone has to fill in email, access token (who will be credited with the releases on npmjs), create Travis account and enable this project.

PS: The publishing part can be disabled.