### PR TITLE
Fix some examples redirecting to examples/examples/…

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -64,9 +64,9 @@
         <a class='exampleLink' href="network/events/renderEvents.html">rendering events, use to draw custom items on the canvas.</a><br />
 
         <h3>dynamic data - dot language</h3>
-        <a class='exampleLink' href="examples/network/data/dotLanguage/dotEdgeStyles.html">DOT edge styles</a><br />
-        <a class='exampleLink' href="examples/network/data/dotLanguage/dotLanguage.html">DOT Language</a><br />
-        <a class='exampleLink' href="examples/network/data/dotLanguage/dotPlayground.html">DOT language playground</a><br />
+        <a class='exampleLink' href="network/data/dotLanguage/dotEdgeStyles.html">DOT edge styles</a><br />
+        <a class='exampleLink' href="network/data/dotLanguage/dotLanguage.html">DOT Language</a><br />
+        <a class='exampleLink' href="network/data/dotLanguage/dotPlayground.html">DOT language playground</a><br />
 
         <h3>dynamic data</h3>
         <a class='exampleLink' href="network/data/datasets.html">dataset for dynamic data</a><br />


### PR DESCRIPTION
Fixes:

> Dynamic data - dot language examples redirect to /examples/examples/… when it should be /examples/….