### PR TITLE
fix: ensure that invalid scale is not passed to moveTo

### DIFF
--- a/lib/network/modules/View.js
+++ b/lib/network/modules/View.js
@@ -142,7 +142,7 @@ class View {
     // Coerce and verify that the scale is valid.
     options.scale = +options.scale
     if (!(options.scale > 0)) {
-      throw new TypeError('Scale has to be a number bigger than zero.')
+      throw new TypeError('The option "scale" has to be a number greater than zero.')
     }
 
     if (options.offset    === undefined)           {options.offset    = {x: 0, y: 0};    }

--- a/lib/network/modules/View.js
+++ b/lib/network/modules/View.js
@@ -138,6 +138,13 @@ class View {
       options = {};
       return;
     }
+
+    // Coerce and verify that the scale is valid.
+    options.scale = +options.scale
+    if (!(options.scale > 0)) {
+      throw new TypeError('Scale has to be a number bigger than zero.')
+    }
+
     if (options.offset    === undefined)           {options.offset    = {x: 0, y: 0};    }
     if (options.offset.x  === undefined)           {options.offset.x  = 0;               }
     if (options.offset.y  === undefined)           {options.offset.y  = 0;               }


### PR DESCRIPTION
Coerce to number and throw if it isn't grater than zero.

Fixes #12.

All MWE from the issue either work correctly or throw right away.