### PR TITLE
fix(build): extend other Vis libraries

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -45,6 +45,7 @@ export default [
 			format: 'umd',
 			exports: 'named',
 			name: 'vis',
+			extend: true,
 			banner: genHeader('network'),
 			sourcemap: true
 		}],
@@ -68,6 +69,7 @@ export default [
 			format: 'umd',
 			exports: 'named',
 			name: 'vis',
+			extend: true,
 			banner: genHeader('network'),
 			sourcemap: true
 		}],


### PR DESCRIPTION
They were overwritten before which resulted in only one Vis library being usable at a time.

Addresses: https://github.com/visjs/vis-network/issues/66.