### PR TITLE
chore(docs): correct nodes.icon.face description

### DIFF
--- a/docs/network/nodes.html
+++ b/docs/network/nodes.html
@@ -692,8 +692,9 @@ network.setOptions(options);
             <td class="indent">icon.face</td>
             <td>String</td>
             <td><code>'FontAwesome'</code></td>
-            <td>These options are only used when the shape is set to <code>icon</code>. The possible options for the
-                face are: <code>'FontAwesome'</code> and <code>'Ionicons'</code>.
+            <td>These options are only used when the shape is set to <code>icon</code>. The possible values for the
+                face option are any font faces that are loaded on given page such as <code>'FontAwesome'</code> or
+                <code>'Ionicons'</code>.
             </td>
         </tr>
         <tr parent="icon" class="hidden">


### PR DESCRIPTION
It used to imply that FontAwesome and Ionicons are the only faces that
can be used. In reality these can only be used if the user ships them
themselves and others can be used too if loaded on the page.

Resolves #59.