### PR TITLE
style(eslint): disable member-ordering

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -75,7 +75,6 @@ module.exports = {
           'error',
           { private: '^_', protected: '^_', public: '^[^_]' },
         ],
-        '@typescript-eslint/member-ordering': 'error',
         '@typescript-eslint/no-parameter-properties': 'off',
         '@typescript-eslint/no-useless-constructor': 'error',
         '@typescript-eslint/prefer-readonly': 'error',
@@ -158,7 +157,6 @@ module.exports = {
           "error",
           { private: "^_", protected: "^_", public: "^[^_]" }
         ],
-        "@typescript-eslint/member-ordering": "error",
         "@typescript-eslint/no-parameter-properties": "off",
         "@typescript-eslint/no-useless-constructor": "error",
         "@typescript-eslint/prefer-readonly": "error",


### PR DESCRIPTION
I thought it would be nice to prevent methods, attributes, etc. from being mixed but it fails when there are abstract methods. It's not particularly necessary anyway.