### PR TITLE
chore(deps): pin runtime dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
     "postinstall": "opencollective postinstall || exit 0"
   },
   "dependencies": {
-    "@egjs/hammerjs": "^2.0.15",
-    "component-emitter": "^1.3.0",
-    "keycharm": "^0.2.0",
-    "moment": "^2.24.0",
-    "timsort": "^0.3.0",
-    "vis-data": "^6.1.1",
-    "vis-util": "^1.1.6"
+    "@egjs/hammerjs": "2.0.15",
+    "component-emitter": "1.3.0",
+    "keycharm": "0.2.0",
+    "moment": "2.24.0",
+    "timsort": "0.3.0",
+    "vis-data": "6.1.1",
+    "vis-util": "1.1.6"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",


### PR DESCRIPTION
Greenkeeper doesn't open a PR when the new version satisfies the range and works. Therefore we receive issues if something breaks and PRs for breaking changes but not for features or fixes. This will make Greenkeeper open a PR for every release.