### PR TITLE
chore(examples): make index page title configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build": "npm run types:network && npm run js:network && npm run images:network",
     "watch": "npm run images:network && rollup --watch --config rollup.config.js",
     "watch-dev": "npm run watch-dev",
-    "generate-examples-index": "node -r ./babel.mocha.js ./scripts/examples-index/generate.ts -c mynetwork -w https://visjs.github.io/vis-network -S ./scripts/examples-index/screenshot-script.js -lis",
+    "generate-examples-index": "node -r ./babel.mocha.js ./scripts/examples-index/generate.ts -t \"Vis Network Examples\" -c mynetwork -w https://visjs.github.io/vis-network -S ./scripts/examples-index/screenshot-script.js -lis",
     "lint": "npm run lint:js && npm run lint:ts",
     "lint:js": "eslint '{lib,test}/**/*.js'",
     "lint:ts": "eslint '{lib,test}/**/*.ts'",

--- a/scripts/examples-index/generate.ts
+++ b/scripts/examples-index/generate.ts
@@ -57,6 +57,12 @@ yargs
     describe:
       "The path of JavaScript file that will be executed before taking a screenshot (and before any other JavaScript in the page).",
     type: "string"
+  })
+  .option("title", {
+    alias: "t",
+    default: "Examples",
+    describe: "The title of the examples index.",
+    type: "string"
   });
 
 // Pageres uses quite a lot of listeners when invoked multiple times in
@@ -677,6 +683,7 @@ const exampleLinter = {
     // Create and write the page.
     if (yargs.argv.index) {
       const page = cheerio.load(await indexTemplate);
+      page("title").text(yargs.argv.title as string);
       page("body").append(await builtData.html);
       await writeFile("./index.html", formatHTML(page.html()));
       console.info(`Index file with ${stats.examples} example(s) was written.`);

--- a/scripts/examples-index/index.template.html
+++ b/scripts/examples-index/index.template.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>Vis Network Examples</title>
+    <title>Examples</title>
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
The title was hardcoded to Vis Network Examples. Now it's reusable across packages.