### PR TITLE
chore(github): update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,11 +2,10 @@
 Please make sure to **read the following list** before creating a new issue:
 
 * This issue tracker is not supposed to be used for questions on how to use visjs. It is intended to be used for bug reports and feature requests! In case you face yourself with a usage question, then post your question e.g. on [stackoverflow](https://stackoverflow.com/questions/tagged/vis.js) tagged with "vis.js".
-* Have you already used the [github search](https://github.com/almende/vis/issues), read the [documentation](http://visjs.org/) and looked at the [examples](https://github.com/almende/vis/tree/develop/examples)?
-* Make sure to mention which vis-component (network, timeline, graph2D, graph3d) you are referring to.
-* Make sure to use the [latest version of vis.js](https://cdnjs.com/libraries/vis) for bug reports.
+* Have you already used the [github search](https://github.com/visjs/vis-network/issues), read the [documentation](http://visjs.org/) and looked at the [examples](https://visjs.github.io/vis-network/examples)?
+* Make sure to use the [latest version of vis-network](https://unpkg.com/vis-network@latest/dist/) for bug reports.
 * Make sure to mention which browser and OS you are using when creating a bug report.
-* Please provide a minimal code example that demonstrates your issue. We recommend using [jsbin](jsbin.com) for that.
+* Please provide a minimal code example that demonstrates your issue. We recommend using [jsbin](https://jsbin.com) for that.
 * Delete this list from the actual issue.
 
 <!-- Love vis? Please consider supporting our collective:


### PR DESCRIPTION
There were links pointing to the legacy Vis.js project. Also this no longer contains anything else but Network so mentioning a component is not necessary anymore.