### PR TITLE
Image arrow heads

### DIFF
--- a/docs/network/edges.html
+++ b/docs/network/edges.html
@@ -114,7 +114,7 @@ var options = {
         imageHeight: 32,
         imageWidth: 32,
         scaleFactor: 1,
-        src: "http://placehold.it/32x32/008888",
+        src: "https://visjs.org/images/visjs_logo.png",
         type: "image"
       },
       from: {

--- a/docs/network/edges.html
+++ b/docs/network/edges.html
@@ -101,9 +101,30 @@
 var options = {
   edges:{
     arrows: {
-      to:     {enabled: false, scaleFactor:1, type:'arrow'},
-      middle: {enabled: false, scaleFactor:1, type:'arrow'},
-      from:   {enabled: false, scaleFactor:1, type:'arrow'}
+      to: {
+        enabled: false,
+        scaleFactor: 1,
+        type: "arrow",
+        src: undefined,
+        imageWidth: undefined,
+        imageHeight: undefined
+      },
+      middle: {
+        enabled: false,
+        scaleFactor: 1,
+        type: "image",
+        src: "http://placehold.it/32x32/008888",
+        imageWidth: 32,
+        imageHeight: 32
+      },
+      from: {
+        enabled: false,
+        scaleFactor: 1,
+        type: "arrow",
+        src: undefined,
+        imageWidth: undefined,
+        imageHeight: undefined
+      }
     },
     arrowStrikethrough: true,
     chosen: true,
@@ -265,7 +286,25 @@ network.setOptions(options);
             <td class="indent2">arrows.to.type</td>
             <td>String</td>
             <td><code>arrow</code></td>
-            <td>The type of endpoint. Possible values are: <code>arrow</code>, <code>bar</code>, <code>circle</code>. The default is <code>arrow</code>.
+            <td>The type of endpoint. Possible values are: <code>arrow</code>, <code>bar</code>, <code>circle</code> and <code>image</code>. The default is <code>arrow</code></td>.
+        </tr>
+        <tr parent="arrows" class="hidden">
+            <td class="indent2">arrows.to.src</td>
+            <td>String</td>
+            <td><code>undefined</code></td>
+            <td>The URL for the image arrow type.</td>.
+        </tr>
+        <tr parent="arrows" class="hidden">
+            <td class="indent2">arrows.to.imageWidth</td>
+            <td>Number</td>
+            <td><code>undefined</code></td>
+            <td>The width of the image arrow. The width of the image file is used if this isn't defined.</td>.
+        </tr>
+        <tr parent="arrows" class="hidden">
+            <td class="indent2">arrows.to.imageHeight</td>
+            <td>Number</td>
+            <td><code>undefined</code></td>
+            <td>The height of the image arrow. The height of the image file is used if this isn't defined.</td>.
         </tr>
         <tr parent="arrows" class="hidden">
             <td class="indent">arrows.middle</td>

--- a/docs/network/edges.html
+++ b/docs/network/edges.html
@@ -103,27 +103,27 @@ var options = {
     arrows: {
       to: {
         enabled: false,
-        scaleFactor: 1,
-        type: "arrow",
-        src: undefined,
+        imageHeight: undefined,
         imageWidth: undefined,
-        imageHeight: undefined
+        scaleFactor: 1,
+        src: undefined,
+        type: "arrow"
       },
       middle: {
         enabled: false,
-        scaleFactor: 1,
-        type: "image",
-        src: "http://placehold.it/32x32/008888",
+        imageHeight: 32,
         imageWidth: 32,
-        imageHeight: 32
+        scaleFactor: 1,
+        src: "http://placehold.it/32x32/008888",
+        type: "image"
       },
       from: {
         enabled: false,
-        scaleFactor: 1,
-        type: "arrow",
-        src: undefined,
+        imageHeight: undefined,
         imageWidth: undefined,
-        imageHeight: undefined
+        scaleFactor: 1,
+        src: undefined,
+        type: "arrow"
       }
     },
     arrowStrikethrough: true,
@@ -277,22 +277,10 @@ network.setOptions(options);
             </td>
         </tr>
         <tr parent="arrows" class="hidden">
-            <td class="indent2">arrows.to.scaleFactor</td>
+            <td class="indent2">arrows.to.imageHeight</td>
             <td>Number</td>
-            <td><code>1</code></td>
-            <td>The scale factor allows you to change the size of the arrowhead.</td>
-        </tr>
-        <tr parent="arrows" class="hidden">
-            <td class="indent2">arrows.to.type</td>
-            <td>String</td>
-            <td><code>arrow</code></td>
-            <td>The type of endpoint. Possible values are: <code>arrow</code>, <code>bar</code>, <code>circle</code> and <code>image</code>. The default is <code>arrow</code></td>.
-        </tr>
-        <tr parent="arrows" class="hidden">
-            <td class="indent2">arrows.to.src</td>
-            <td>String</td>
             <td><code>undefined</code></td>
-            <td>The URL for the image arrow type.</td>.
+            <td>The height of the image arrow. The height of the image file is used if this isn't defined.</td>.
         </tr>
         <tr parent="arrows" class="hidden">
             <td class="indent2">arrows.to.imageWidth</td>
@@ -301,10 +289,22 @@ network.setOptions(options);
             <td>The width of the image arrow. The width of the image file is used if this isn't defined.</td>.
         </tr>
         <tr parent="arrows" class="hidden">
-            <td class="indent2">arrows.to.imageHeight</td>
+            <td class="indent2">arrows.to.scaleFactor</td>
             <td>Number</td>
+            <td><code>1</code></td>
+            <td>The scale factor allows you to change the size of the arrowhead.</td>
+        </tr>
+        <tr parent="arrows" class="hidden">
+            <td class="indent2">arrows.to.src</td>
+            <td>String</td>
             <td><code>undefined</code></td>
-            <td>The height of the image arrow. The height of the image file is used if this isn't defined.</td>.
+            <td>The URL for the image arrow type.</td>.
+        </tr>
+        <tr parent="arrows" class="hidden">
+            <td class="indent2">arrows.to.type</td>
+            <td>String</td>
+            <td><code>arrow</code></td>
+            <td>The type of endpoint. Possible values are: <code>arrow</code>, <code>bar</code>, <code>circle</code> and <code>image</code>. The default is <code>arrow</code></td>.
         </tr>
         <tr parent="arrows" class="hidden">
             <td class="indent">arrows.middle</td>

--- a/examples/network/edgeStyles/imageArrowHeads.html
+++ b/examples/network/edgeStyles/imageArrowHeads.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Vis Network | Edge Styles | Image Arrow Heads</title>
+
+    <style type="text/css">
+      html,
+      body,
+      #mynetwork {
+        margin: 0px;
+        padding: 0px;
+      }
+
+      #mynetwork {
+        position: fixed;
+        left: 0px;
+        top: 0px;
+        bottom: 0px;
+        right: 50%;
+        min-height: 100vh;
+        border-right: 1px solid lightgray;
+        background: white;
+      }
+
+      #text {
+        position: absolute;
+        left: 50%;
+        right: 0%;
+        padding: 1em;
+      }
+
+      #title {
+        margin-bottom: 5em;
+      }
+
+      pre {
+        overflow-x: auto;
+      }
+    </style>
+
+    <script
+      type="text/javascript"
+      src="../../../../dist/vis-network.min.js"
+    ></script>
+    <link
+      href="../../../../dist/vis-network.min.css"
+      rel="stylesheet"
+      type="text/css"
+    />
+  </head>
+
+  <body>
+    <div id="text">
+      <div id="title">
+        <h1>Vis Network</h1>
+        <h2>Edge Styles</h2>
+        <h3>Image Arrow Heads</h3>
+      </div>
+
+      <ul>
+        <li>
+          All formats supported by canvas are supported here (like SVG, PNG,
+          JPG).
+        </li>
+        <li>Image can be specified using any URL including data URLs.</li>
+        <li>
+          Width and height can be set explicitly to scale the image to the
+          desired size.
+        </li>
+        <li>
+          The arrow head points to the top with the point in the middle of the
+          top edge of the image.
+        </li>
+      </ul>
+
+      <pre><code>
+const options = {
+  edges: {
+    arrows: {
+      to: {
+        enabled: true,
+        type: "image",
+        imageWidth: 24,
+        imageHeight: 24,
+        src:
+          "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' style='width:24px;height:24px' viewBox='0 0 24 24'%3E%3Cpath fill='%23000000' d='M19,3A2,2 0 0,1 21,5V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V5A2,2 0 0,1 5,3H9.18C9.6,1.84 10.7,1 12,1C13.3,1 14.4,1.84 14.82,3H19M12,8L7,13H10V17H14V13H17L12,8M12,3A1,1 0 0,0 11,4A1,1 0 0,0 12,5A1,1 0 0,0 13,4A1,1 0 0,0 12,3Z' /%3E%3C/svg%3E"
+      }
+    }
+  }
+};
+      </code></pre>
+    </div>
+
+    <div id="mynetwork"></div>
+    <script type="text/javascript">
+      // create an array with nodes
+      var nodes = new vis.DataSet([
+        { id: 1, label: "Node 1" },
+        { id: 2, label: "Node 2" },
+        { id: 3, label: "Node 3" },
+        { id: 4, label: "Node 4" },
+        { id: 5, label: "Node 5" }
+      ]);
+
+      // create an array with edges
+      var edges = new vis.DataSet([
+        { from: 1, to: 3 },
+        { from: 1, to: 2 },
+        { from: 2, to: 4 },
+        { from: 2, to: 5 },
+        { from: 3, to: 3 }
+      ]);
+
+      // create a network
+      var container = document.getElementById("mynetwork");
+      var data = {
+        nodes: nodes,
+        edges: edges
+      };
+      var options = {
+        edges: {
+          arrows: {
+            to: {
+              enabled: true,
+              type: "image",
+              imageWidth: 24,
+              imageHeight: 24,
+              src:
+                "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' style='width:24px;height:24px' viewBox='0 0 24 24'%3E%3Cpath fill='%23000000' d='M19,3A2,2 0 0,1 21,5V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V5A2,2 0 0,1 5,3H9.18C9.6,1.84 10.7,1 12,1C13.3,1 14.4,1.84 14.82,3H19M12,8L7,13H10V17H14V13H17L12,8M12,3A1,1 0 0,0 11,4A1,1 0 0,0 12,5A1,1 0 0,0 13,4A1,1 0 0,0 12,3Z' /%3E%3C/svg%3E"
+            }
+          }
+        }
+      };
+      var network = new vis.Network(container, data, options);
+    </script>
+  </body>
+</html>

--- a/lib/network/modules/EdgesHandler.js
+++ b/lib/network/modules/EdgesHandler.js
@@ -383,7 +383,13 @@ class EdgesHandler {
    * @returns {Edge}
    */
   create(properties) {
-    return new Edge(properties, this.body, this.options, this.defaultOptions)
+    return new Edge(
+      properties,
+      this.body,
+      this.images,
+      this.options,
+      this.defaultOptions
+    );
   }
 
   /**

--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -10,10 +10,11 @@ class Edge {
   /**
    * @param {Object} options        values specific to this edge, must contain at least 'from' and 'to'
    * @param {Object} body           shared state from Network instance
+   * @param {Network.Images} imagelist  A list with images. Only needed when the edge has image arrows.
    * @param {Object} globalOptions  options from the EdgesHandler instance
    * @param {Object} defaultOptions default options from the EdgeHandler instance. Value and reference are constant
    */
-  constructor(options, body, globalOptions, defaultOptions) {
+  constructor(options, body, imagelist, globalOptions, defaultOptions) {
     if (body === undefined) {
       throw new Error("No body provided");
     }
@@ -25,6 +26,7 @@ class Edge {
     this.globalOptions = globalOptions;
     this.defaultOptions = defaultOptions;
     this.body = body;
+    this.imagelist = imagelist;
 
     // initialize variables
     this.id = undefined;
@@ -263,12 +265,21 @@ class Edge {
       toArrow: toArrow,
       toArrowScale: this.options.arrows.to.scaleFactor,
       toArrowType: this.options.arrows.to.type,
+      toArrowSrc: this.options.arrows.to.src,
+      toArrowImageWidth: this.options.arrows.to.imageWidth,
+      toArrowImageHeight: this.options.arrows.to.imageHeight,
       middleArrow: middleArrow,
       middleArrowScale: this.options.arrows.middle.scaleFactor,
       middleArrowType: this.options.arrows.middle.type,
+      middleArrowSrc: this.options.arrows.middle.src,
+      middleArrowImageWidth: this.options.arrows.middle.imageWidth,
+      middleArrowImageHeight: this.options.arrows.middle.imageHeight,
       fromArrow: fromArrow,
       fromArrowScale: this.options.arrows.from.scaleFactor,
       fromArrowType: this.options.arrows.from.type,
+      fromArrowSrc: this.options.arrows.from.src,
+      fromArrowImageWidth: this.options.arrows.from.imageWidth,
+      fromArrowImageHeight: this.options.arrows.from.imageHeight,
       arrowStrikethrough: this.options.arrowStrikethrough,
       color: (inheritsColor? undefined : this.options.color.color),
       inheritsColor: inheritsColor,
@@ -535,19 +546,67 @@ class Edge {
 
     // from and to arrows give a different end point for edges. we set them here
     if (values.fromArrow) {
-      arrowData.from = this.edgeType.getArrowData(ctx, 'from', viaNode, this.selected, this.hover, values);
+      arrowData.from = this.edgeType.getArrowData(
+        ctx,
+        "from",
+        viaNode,
+        this.selected,
+        this.hover,
+        values
+      );
       if (values.arrowStrikethrough === false)
         this.edgeType.fromPoint = arrowData.from.core;
+      if (values.fromArrowSrc) {
+        arrowData.from.image = this.imagelist.load(values.fromArrowSrc);
+      }
+      if (values.fromArrowImageWidth) {
+        arrowData.from.imageWidth = values.fromArrowImageWidth;
+      }
+      if (values.fromArrowImageHeight) {
+        arrowData.from.imageHeight = values.fromArrowImageHeight;
+      }
     }
     if (values.toArrow) {
-      arrowData.to = this.edgeType.getArrowData(ctx, 'to', viaNode, this.selected, this.hover, values);
+      arrowData.to = this.edgeType.getArrowData(
+        ctx,
+        "to",
+        viaNode,
+        this.selected,
+        this.hover,
+        values
+      );
       if (values.arrowStrikethrough === false)
         this.edgeType.toPoint = arrowData.to.core;
+      if (values.toArrowSrc) {
+        arrowData.to.image = this.imagelist.load(values.toArrowSrc);
+      }
+      if (values.toArrowImageWidth) {
+        arrowData.to.imageWidth = values.toArrowImageWidth;
+      }
+      if (values.toArrowImageHeight) {
+        arrowData.to.imageHeight = values.toArrowImageHeight;
+      }
     }
 
     // the middle arrow depends on the line, which can depend on the to and from arrows so we do this one lastly.
     if (values.middleArrow) {
-      arrowData.middle = this.edgeType.getArrowData(ctx,'middle', viaNode, this.selected, this.hover, values);
+      arrowData.middle = this.edgeType.getArrowData(
+        ctx,
+        "middle",
+        viaNode,
+        this.selected,
+        this.hover,
+        values
+      );
+      if (values.middleArrowSrc) {
+        arrowData.middle.image = this.imagelist.load(values.middleArrowSrc);
+      }
+      if (values.middleArrowImageWidth) {
+        arrowData.middle.imageWidth = values.middleArrowImageWidth;
+      }
+      if (values.middleArrowImageHeight) {
+        arrowData.middle.imageHeight = values.middleArrowImageHeight;
+      }
     }
 
     // draw everything

--- a/lib/network/modules/components/edges/util/edge-base.ts
+++ b/lib/network/modules/components/edges/util/edge-base.ts
@@ -798,13 +798,15 @@ export abstract class EdgeBase<Via = undefined> implements EdgeType {
     ctx.fillStyle = ctx.strokeStyle;
     ctx.lineWidth = values.width;
 
-    EndPoints.draw(ctx, arrowData);
+    const canFill = EndPoints.draw(ctx, arrowData);
 
-    // draw shadow if enabled
-    this.enableShadow(ctx, values);
-    ctx.fill();
-    // disable shadows for other elements.
-    this.disableShadow(ctx, values);
+    if (canFill) {
+      // draw shadow if enabled
+      this.enableShadow(ctx, values);
+      ctx.fill();
+      // disable shadows for other elements.
+      this.disableShadow(ctx, values);
+    }
   }
 
   /**

--- a/lib/network/modules/components/edges/util/end-points.ts
+++ b/lib/network/modules/components/edges/util/end-points.ts
@@ -83,17 +83,67 @@ class EndPoint {
 /**
  * Drawing methods for the arrow endpoint.
  */
+class Image extends EndPoint {
+  /**
+   * Draw this shape at the end of a line.
+   *
+   * @param ctx - The shape will be rendered into this context.
+   * @param arrowData - The data determining the shape.
+   *
+   * @returns False as there is no way to fill an image.
+   */
+  public static draw(
+    ctx: CanvasRenderingContext2D,
+    arrowData: ArrowData
+  ): false {
+    if (arrowData.image) {
+      ctx.save();
+
+      ctx.translate(arrowData.point.x, arrowData.point.y);
+      ctx.rotate(Math.PI / 2 + arrowData.angle);
+
+      const width =
+        arrowData.imageWidth != null
+          ? arrowData.imageWidth
+          : arrowData.image.width;
+      const height =
+        arrowData.imageHeight != null
+          ? 
+        arrowData.imageHeight
+          : arrowData.image.height;
+
+      arrowData.image.drawImageAtPosition(
+        ctx,
+        1, // scale
+        -width / 2, // x
+        0, // y
+        width,
+        height
+      );
+
+      ctx.restore();
+    }
+
+    return false;
+  }
+}
+
+/**
+ * Drawing methods for the arrow endpoint.
+ */
 class Arrow extends EndPoint {
   /**
    * Draw this shape at the end of a line.
    *
    * @param ctx - The shape will be rendered into this context.
    * @param arrowData - The data determining the shape.
+   *
+   * @returns True because ctx.fill() can be used to fill the arrow.
    */
   public static draw(
     ctx: CanvasRenderingContext2D,
     arrowData: ArrowData
-  ): void {
+  ): true {
     // Normalized points of closed path, in the order that they should be drawn.
     // (0, 0) is the attachment point, and the point around which should be rotated
     const points = [
@@ -105,6 +155,8 @@ class Arrow extends EndPoint {
 
     EndPoint.transform(points, arrowData);
     EndPoint.drawPath(ctx, points);
+
+    return true;
   }
 }
 
@@ -117,11 +169,13 @@ class Crow {
    *
    * @param ctx - The shape will be rendered into this context.
    * @param arrowData - The data determining the shape.
+   *
+   * @returns True because ctx.fill() can be used to fill the arrow.
    */
   public static draw(
     ctx: CanvasRenderingContext2D,
     arrowData: ArrowData
-  ): void {
+  ): true {
     // Normalized points of closed path, in the order that they should be drawn.
     // (0, 0) is the attachment point, and the point around which should be rotated
     const points = [
@@ -133,6 +187,8 @@ class Crow {
 
     EndPoint.transform(points, arrowData);
     EndPoint.drawPath(ctx, points);
+
+    return true;
   }
 }
 
@@ -145,11 +201,13 @@ class Curve {
    *
    * @param ctx - The shape will be rendered into this context.
    * @param arrowData - The data determining the shape.
+   *
+   * @returns True because ctx.fill() can be used to fill the arrow.
    */
   public static draw(
     ctx: CanvasRenderingContext2D,
     arrowData: ArrowData
-  ): void {
+  ): true {
     // Normalized points of closed path, in the order that they should be drawn.
     // (0, 0) is the attachment point, and the point around which should be rotated
     const point = { x: -0.4, y: 0 };
@@ -173,6 +231,8 @@ class Curve {
       false
     );
     ctx.stroke();
+
+    return true;
   }
 }
 
@@ -185,11 +245,13 @@ class InvertedCurve {
    *
    * @param ctx - The shape will be rendered into this context.
    * @param arrowData - The data determining the shape.
+   *
+   * @returns True because ctx.fill() can be used to fill the arrow.
    */
   public static draw(
     ctx: CanvasRenderingContext2D,
     arrowData: ArrowData
-  ): void {
+  ): true {
     // Normalized points of closed path, in the order that they should be drawn.
     // (0, 0) is the attachment point, and the point around which should be rotated
     const point = { x: -0.3, y: 0 };
@@ -213,6 +275,8 @@ class InvertedCurve {
       false
     );
     ctx.stroke();
+
+    return true;
   }
 }
 
@@ -225,17 +289,21 @@ class Triangle {
    *
    * @param ctx - The shape will be rendered into this context.
    * @param arrowData - The data determining the shape.
+   *
+   * @returns True because ctx.fill() can be used to fill the arrow.
    */
   public static draw(
     ctx: CanvasRenderingContext2D,
     arrowData: ArrowData
-  ): void {
+  ): true {
     // Normalized points of closed path, in the order that they should be drawn.
     // (0, 0) is the attachment point, and the point around which should be rotated
     const points = [{ x: 0.02, y: 0 }, { x: -1, y: 0.3 }, { x: -1, y: -0.3 }];
 
     EndPoint.transform(points, arrowData);
     EndPoint.drawPath(ctx, points);
+
+    return true;
   }
 }
 
@@ -248,17 +316,21 @@ class InvertedTriangle {
    *
    * @param ctx - The shape will be rendered into this context.
    * @param arrowData - The data determining the shape.
+   *
+   * @returns True because ctx.fill() can be used to fill the arrow.
    */
   public static draw(
     ctx: CanvasRenderingContext2D,
     arrowData: ArrowData
-  ): void {
+  ): true {
     // Normalized points of closed path, in the order that they should be drawn.
     // (0, 0) is the attachment point, and the point around which should be rotated
     const points = [{ x: 0, y: 0.3 }, { x: 0, y: -0.3 }, { x: -1, y: 0 }];
 
     EndPoint.transform(points, arrowData);
     EndPoint.drawPath(ctx, points);
+
+    return true;
   }
 }
 
@@ -271,15 +343,19 @@ class Circle {
    *
    * @param ctx - The shape will be rendered into this context.
    * @param arrowData - The data determining the shape.
+   *
+   * @returns True because ctx.fill() can be used to fill the arrow.
    */
   public static draw(
     ctx: CanvasRenderingContext2D,
     arrowData: ArrowData
-  ): void {
+  ): true {
     const point = { x: -0.4, y: 0 };
 
     EndPoint.transform(point, arrowData);
     ctx.circle(point.x, point.y, arrowData.length * 0.4);
+
+    return true;
   }
 }
 
@@ -292,11 +368,13 @@ class Bar {
    *
    * @param ctx - The shape will be rendered into this context.
    * @param arrowData - The data determining the shape.
+   *
+   * @returns True because ctx.fill() can be used to fill the arrow.
    */
   public static draw(
     ctx: CanvasRenderingContext2D,
     arrowData: ArrowData
-  ): void {
+  ): true {
     /*
     var points = [
       {x:0, y:0.5},
@@ -319,6 +397,8 @@ class Bar {
 
     EndPoint.transform(points, arrowData);
     EndPoint.drawPath(ctx, points);
+
+    return true;
   }
 }
 
@@ -331,11 +411,13 @@ class Box {
    *
    * @param ctx - The shape will be rendered into this context.
    * @param arrowData - The data determining the shape.
+   *
+   * @returns True because ctx.fill() can be used to fill the arrow.
    */
   public static draw(
     ctx: CanvasRenderingContext2D,
     arrowData: ArrowData
-  ): void {
+  ): true {
     const points = [
       { x: 0, y: 0.3 },
       { x: 0, y: -0.3 },
@@ -345,6 +427,8 @@ class Box {
 
     EndPoint.transform(points, arrowData);
     EndPoint.drawPath(ctx, points);
+
+    return true;
   }
 }
 
@@ -357,11 +441,13 @@ class Diamond {
    *
    * @param ctx - The shape will be rendered into this context.
    * @param arrowData - The data determining the shape.
+   *
+   * @returns True because ctx.fill() can be used to fill the arrow.
    */
   public static draw(
     ctx: CanvasRenderingContext2D,
     arrowData: ArrowData
-  ): void {
+  ): true {
     const points = [
       { x: 0, y: 0 },
       { x: -0.5, y: -0.3 },
@@ -371,6 +457,8 @@ class Diamond {
 
     EndPoint.transform(points, arrowData);
     EndPoint.drawPath(ctx, points);
+
+    return true;
   }
 }
 
@@ -383,11 +471,13 @@ class Vee {
    *
    * @param ctx - The shape will be rendered into this context.
    * @param arrowData - The data determining the shape.
+   *
+   * @returns True because ctx.fill() can be used to fill the arrow.
    */
   public static draw(
     ctx: CanvasRenderingContext2D,
     arrowData: ArrowData
-  ): void {
+  ): true {
     // Normalized points of closed path, in the order that they should be drawn.
     // (0, 0) is the attachment point, and the point around which should be rotated
     const points = [
@@ -399,6 +489,8 @@ class Vee {
 
     EndPoint.transform(points, arrowData);
     EndPoint.drawPath(ctx, points);
+
+    return true;
   }
 }
 
@@ -411,50 +503,44 @@ export class EndPoints {
    *
    * @param ctx - The shape will be rendered into this context.
    * @param arrowData - The data determining the shape.
+   *
+   * @returns True if ctx.fill() can be used to fill the arrow, false otherwise.
    */
   public static draw(
     ctx: CanvasRenderingContext2D,
     arrowData: ArrowData
-  ): void {
+  ): boolean {
     let type;
     if (arrowData.type) {
       type = arrowData.type.toLowerCase();
     }
 
     switch (type) {
+      case "image":
+        return Image.draw(ctx, arrowData);
       case "circle":
-        Circle.draw(ctx, arrowData);
-        break;
+        return Circle.draw(ctx, arrowData);
       case "box":
-        Box.draw(ctx, arrowData);
-        break;
+        return Box.draw(ctx, arrowData);
       case "crow":
-        Crow.draw(ctx, arrowData);
-        break;
+        return Crow.draw(ctx, arrowData);
       case "curve":
-        Curve.draw(ctx, arrowData);
-        break;
+        return Curve.draw(ctx, arrowData);
       case "diamond":
-        Diamond.draw(ctx, arrowData);
-        break;
+        return Diamond.draw(ctx, arrowData);
       case "inv_curve":
-        InvertedCurve.draw(ctx, arrowData);
-        break;
+        return InvertedCurve.draw(ctx, arrowData);
       case "triangle":
-        Triangle.draw(ctx, arrowData);
-        break;
+        return Triangle.draw(ctx, arrowData);
       case "inv_triangle":
-        InvertedTriangle.draw(ctx, arrowData);
-        break;
+        return InvertedTriangle.draw(ctx, arrowData);
       case "bar":
-        Bar.draw(ctx, arrowData);
-        break;
+        return Bar.draw(ctx, arrowData);
       case "vee":
-        Vee.draw(ctx, arrowData);
-        break;
+        return Vee.draw(ctx, arrowData);
       case "arrow": // fall-through
       default:
-        Arrow.draw(ctx, arrowData);
+        return Arrow.draw(ctx, arrowData);
     }
   }
 }

--- a/lib/network/modules/components/edges/util/end-points.ts
+++ b/lib/network/modules/components/edges/util/end-points.ts
@@ -108,8 +108,7 @@ class Image extends EndPoint {
           : arrowData.image.width;
       const height =
         arrowData.imageHeight != null
-          ? 
-        arrowData.imageHeight
+          ? arrowData.imageHeight
           : arrowData.image.height;
 
       arrowData.image.drawImageAtPosition(

--- a/lib/network/modules/components/edges/util/types.ts
+++ b/lib/network/modules/components/edges/util/types.ts
@@ -43,6 +43,7 @@ export type ArrowType =
   | "crow"
   | "curve"
   | "diamond"
+  | "image"
   | "inv_curve"
   | "inv_triangle"
   | "triangle"
@@ -50,8 +51,23 @@ export type ArrowType =
 
 export type ColorInheritance = boolean | "both" | "from" | "to";
 
+export interface CachedImage {
+  width: number;
+  height: number;
+  drawImageAtPosition(
+    ctx: CanvasRenderingContext2D,
+    factor: number,
+    left: number,
+    top: number,
+    width?: number,
+    height?: number
+  ): void;
+}
 export interface ArrowData {
   angle: number;
+  image?: CachedImage;
+  imageHeight?: number;
+  imageWidth?: number;
   length: number;
   point: Point;
   type: ArrowType;

--- a/lib/network/options.js
+++ b/lib/network/options.js
@@ -14,7 +14,20 @@ let dom = 'dom';
 let any = 'any';
 
 // List of endpoints
-let endPoints = ['arrow', 'circle', 'bar'];
+let endPoints = [
+  "arrow",
+  "bar",
+  "box",
+  "circle",
+  "crow",
+  "curve",
+  "diamond",
+  "image",
+  "inv_curve",
+  "inv_triangle",
+  "triangle",
+  "vee"
+];
 
 let allOptions = {
   configure: {
@@ -26,9 +39,9 @@ let allOptions = {
   },
   edges: {
     arrows: {
-      to: { enabled: { boolean: bool }, scaleFactor: { number }, type: { string: endPoints }, __type__: { object, boolean: bool } },
-      middle: { enabled: { boolean: bool }, scaleFactor: { number }, type: { string: endPoints }, __type__: { object, boolean: bool } },
-      from: { enabled: { boolean: bool }, scaleFactor: { number }, type: { string: endPoints }, __type__: { object, boolean: bool } },
+      to: { enabled: { boolean: bool }, scaleFactor: { number }, type: { string: endPoints }, imageWidth: { number }, imageHeight: { number }, src: { string }, __type__: { object, boolean: bool } },
+      middle: { enabled: { boolean: bool }, scaleFactor: { number }, type: { string: endPoints }, imageWidth: { number }, imageHeight: { number }, src: { string }, __type__: { object, boolean: bool } },
+      from: { enabled: { boolean: bool }, scaleFactor: { number }, type: { string: endPoints }, imageWidth: { number }, imageHeight: { number }, src: { string }, __type__: { object, boolean: bool } },
       __type__: { string: ['from', 'to', 'middle'], object }
     },
     arrowStrikethrough: { boolean: bool },

--- a/lib/network/options.js
+++ b/lib/network/options.js
@@ -39,10 +39,34 @@ let allOptions = {
   },
   edges: {
     arrows: {
-      to: { enabled: { boolean: bool }, scaleFactor: { number }, type: { string: endPoints }, imageWidth: { number }, imageHeight: { number }, src: { string }, __type__: { object, boolean: bool } },
-      middle: { enabled: { boolean: bool }, scaleFactor: { number }, type: { string: endPoints }, imageWidth: { number }, imageHeight: { number }, src: { string }, __type__: { object, boolean: bool } },
-      from: { enabled: { boolean: bool }, scaleFactor: { number }, type: { string: endPoints }, imageWidth: { number }, imageHeight: { number }, src: { string }, __type__: { object, boolean: bool } },
-      __type__: { string: ['from', 'to', 'middle'], object }
+      to: {
+        enabled: { boolean: bool },
+        scaleFactor: { number },
+        type: { string: endPoints },
+        imageHeight: { number },
+        imageWidth: { number },
+        src: { string },
+        __type__: { object, boolean: bool }
+      },
+      middle: {
+        enabled: { boolean: bool },
+        scaleFactor: { number },
+        type: { string: endPoints },
+        imageWidth: { number },
+        imageHeight: { number },
+        src: { string },
+        __type__: { object, boolean: bool }
+      },
+      from: {
+        enabled: { boolean: bool },
+        scaleFactor: { number },
+        type: { string: endPoints },
+        imageWidth: { number },
+        imageHeight: { number },
+        src: { string },
+        __type__: { object, boolean: bool }
+      },
+      __type__: { string: ["from", "to", "middle"], object }
     },
     arrowStrikethrough: { boolean: bool },
     background: {


### PR DESCRIPTION
Adds image arrow heads in similar fashion to image nodes.

Working example: http://jsfiddle.net/thomaash/67xaky4s/.

Todo:
- [x] Implement it.
- [x] Create an example.
- [x] Write docs.

Closes #153.