### PR TITLE
feat(hierarchical-layout): add shake towards option

### DIFF
--- a/docs/network/layout.html
+++ b/docs/network/layout.html
@@ -103,7 +103,8 @@ var options = {
       edgeMinimization: true,
       parentCentralization: true,
       direction: 'UD',        // UD, DU, LR, RL
-      sortMethod: 'hubsize'   // hubsize, directed
+      sortMethod: 'hubsize',  // hubsize, directed
+      shakeTowards: 'leaves'  // roots, leaves
     }
   }
 }
@@ -141,6 +142,7 @@ network.setOptions(options);
         <tr parent="hierarchical" class="hidden"><td class="indent">hierarchical.sortMethod</td><td>String</td><td><code>'hubsize'</code></td>  <td>The algorithm used to ascertain the levels of the nodes based on the data. The possible options are: <code>hubsize, directed</code>. <br><br>
             Hubsize takes the nodes with the most edges and puts them at the top. From that the rest of the hierarchy is evaluated. <br><br>
             Directed adheres to the to and from data of the edges. A --> B so B is a level lower than A.</td></tr>
+        <tr parent="hierarchical" class="hidden"><td class="indent">hierarchical.shakeTowards</td><td>String</td><td><code>'roots'</code></td>        <td>Controls whether in <code>directed</code> layout should all the roots be lined up at the top and their child nodes as close to their roots as possible (<code>roots</code>) or all the leaves lined up at the bottom and their parents as close to their children as possible (<code>leaves</code>, default).</td></tr>
     </table>
 
 </div>

--- a/examples/network/layout/hierarchicalLayoutMethods.html
+++ b/examples/network/layout/hierarchicalLayoutMethods.html
@@ -19,7 +19,6 @@
 
   <script type="text/javascript">
     var network = null;
-    var layoutMethod = "directed";
 
     function destroy() {
       if (network !== null) {
@@ -65,7 +64,8 @@
       var options = {
         layout: {
           hierarchical: {
-            sortMethod: layoutMethod
+            sortMethod: document.getElementById("layout-method").value,
+            shakeTowards: document.getElementById("shake-towards").value
           }
         },
         edges: {
@@ -80,29 +80,48 @@
   
 </head>
 
-<body onload="draw();">
-<h2>Hierarchical layout difference</h2>
-<div style="width:700px; font-size:14px; text-align: justify;">
-  This example shows a the effect of the different hierarchical layout methods. Hubsize is based on the amount of edges connected to a node.
-  The node with the most connections (the largest hub) is drawn at the top of the tree. The direction method is based on the direction of the edges.
-  Try switching between the methods with the dropdown box below.
-</div>
-Layout method:
-<select id="layout">
-  <option value="hubsize">hubsize</option>
-  <option value="directed">directed</option>
-</select><br/>
-<br />
+  <body onload="draw();">
+    <h2>Hierarchical layout difference</h2>
+    <div style="width:700px; font-size:14px; text-align: justify;">
+      This example shows a the effect of the different hierarchical layout
+      methods. Hubsize is based on the amount of edges connected to a node. The
+      node with the most connections (the largest hub) is drawn at the top of
+      the tree. The direction method is based on the direction of the edges. Try
+      switching between the methods by clicking on the buttons bellow.
+    </div>
 
-<div id="mynetwork"></div>
+    <p>
+      Layout method:
+      <input type="button" id="layout-method" value="directed" />
+    </p>
+    <p>
+      Shake towards:
+      <input type="button" id="shake-towards" value="leaves" />
+      (Applies to <code>directed</code> only.)
+    </p>
 
-<p id="selection"></p>
-<script language="JavaScript">
-  var dropdown = document.getElementById("layout");
-  dropdown.onchange = function() {
-    layoutMethod = dropdown.value;
-    draw();
-  }
-</script>
-</body>
+    <div id="mynetwork"></div>
+
+    <p id="selection"></p>
+    <script language="JavaScript">
+      (function() {
+        const values = ["hubsize", "directed"];
+        var button = document.getElementById("layout-method");
+        button.onclick = function() {
+          button.value =
+            values[(values.indexOf(button.value) + 1) % values.length];
+          draw();
+        };
+      })();
+      (function() {
+        const values = ["roots", "leaves"];
+        var button = document.getElementById("shake-towards");
+        button.onclick = function() {
+          button.value =
+            values[(values.indexOf(button.value) + 1) % values.length];
+          draw();
+        };
+      })();
+    </script>
+  </body>
 </html>

--- a/lib/network/modules/LayoutEngine.js
+++ b/lib/network/modules/LayoutEngine.js
@@ -34,7 +34,10 @@ import TimSort from 'timsort';
 import util from 'vis-util';
 import NetworkUtil from '../NetworkUtil';
 import { HorizontalStrategy, VerticalStrategy } from './components/DirectionStrategy.js';
-import { fillLevelsByDirection } from './layout-engine'
+import {
+  fillLevelsByDirectionLeaves,
+  fillLevelsByDirectionRoots
+} from "./layout-engine";
 
 
 /**
@@ -1500,10 +1503,21 @@ class LayoutEngine {
    * @private
    */
   _determineLevelsDirected() {
-    this.hierarchical.levels = fillLevelsByDirection(
-      this.body.nodeIndices.map(id => this.body.nodes[id]),
-      this.hierarchical.levels
-    );
+    const nodes = this.body.nodeIndices.map(id => this.body.nodes[id]);
+    const levels = this.hierarchical.levels;
+
+    if (this.options.hierarchical.shakeTowards === "roots") {
+      this.hierarchical.levels = fillLevelsByDirectionRoots(
+        nodes,
+        this.hierarchical.levels
+      );
+    } else {
+      this.hierarchical.levels = fillLevelsByDirectionLeaves(
+        nodes,
+        this.hierarchical.levels
+      );
+    }
+
     this.hierarchical.setMinLevelToZero(this.body.nodes);
   }
 

--- a/lib/network/modules/layout-engine/index.ts
+++ b/lib/network/modules/layout-engine/index.ts
@@ -125,8 +125,8 @@ function fillLevelsByDirection(
 
     const stack: Node[] = [entryNode];
     let done = 0;
-    let node: Node;
-    while ((node = stack.pop()!)) {
+    let node: Node | undefined;
+    while ((node = stack.pop())) {
       const newLevel = levels[node.id] + newLevelDiff;
 
       node.edges

--- a/lib/network/modules/layout-engine/index.ts
+++ b/lib/network/modules/layout-engine/index.ts
@@ -62,7 +62,7 @@ export function fillLevelsByDirectionLeaves(
     (node): boolean => !node.edges.every((edge): boolean => edge.to === node),
     // Use the lowest level.
     (newLevel, oldLevel): boolean => oldLevel > newLevel,
-    // Go agains the direction of the edges.
+    // Go against the direction of the edges.
     "from",
     nodes,
     levels

--- a/lib/network/modules/layout-engine/index.ts
+++ b/lib/network/modules/layout-engine/index.ts
@@ -92,6 +92,10 @@ export function fillLevelsByDirectionRoots(
 /**
  * Assign levels to nodes according to their positions in the hierarchy.
  *
+ * @param isEntryNode - Checks and return true if the graph should be traversed from this node.
+ * @param shouldEdgeBeFollowed - Checks and returns true if the traversal should continue further through this edge.
+ * @param shouldLevelBeReplaced - Checks and returns true if the level of given node should be updated to the new value.
+ * @param direction - Wheter the graph should be traversed in the direction of the edges `"to"` or in the other way `"from"`.
  * @param nodes - Nodes of the graph.
  * @param levels - If present levels will be added to it, if not a new object will be created.
  *

--- a/lib/network/options.js
+++ b/lib/network/options.js
@@ -185,6 +185,7 @@ let allOptions = {
       parentCentralization: { boolean: bool },
       direction: { string: ['UD', 'DU', 'LR', 'RL'] },   // UD, DU, LR, RL
       sortMethod: { string: ['hubsize', 'directed'] }, // hubsize, directed
+      shakeTowards: { string: ['leaves', 'roots'] }, // leaves, roots
       __type__: { object, boolean: bool }
     },
     __type__: { object }
@@ -563,7 +564,8 @@ let configureOptions = {
       edgeMinimization: true,
       parentCentralization: true,
       direction: ['UD', 'DU', 'LR', 'RL'],   // UD, DU, LR, RL
-      sortMethod: ['hubsize', 'directed'] // hubsize, directed
+      sortMethod: ['hubsize', 'directed'], // hubsize, directed
+      shakeTowards: ['leaves', 'roots'] // leaves, roots
     }
   },
   interaction: {


### PR DESCRIPTION
This allows users to shake the nodes towards the leaves (default as it
was this way already) or the roots (this was the way it worked back when
the layout was broken) of the hierarchy if they so choose.

Closes #176.