### PR TITLE
chore(examples): fix broken script paths

### DIFF
--- a/examples/network/edgeStyles/imageArrowHeads.html
+++ b/examples/network/edgeStyles/imageArrowHeads.html
@@ -41,10 +41,10 @@
 
     <script
       type="text/javascript"
-      src="../../../../dist/vis-network.min.js"
+      src="../../../dist/vis-network.min.js"
     ></script>
     <link
-      href="../../../../dist/vis-network.min.css"
+      href="../../../dist/vis-network.min.css"
       rel="stylesheet"
       type="text/css"
     />

--- a/examples/network/layout/hierarchicalLayoutOverlapAvoidance.html
+++ b/examples/network/layout/hierarchicalLayoutOverlapAvoidance.html
@@ -35,10 +35,10 @@
 
     <script
       type="text/javascript"
-      src="../../../../dist/vis-network.min.js"
+      src="../../../dist/vis-network.min.js"
     ></script>
     <link
-      href="../../../../dist/vis-network.min.css"
+      href="../../../dist/vis-network.min.css"
       rel="stylesheet"
       type="text/css"
     />


### PR DESCRIPTION
Some paths in the examples pointed to nonexistent files. This fixes that.