### PR TITLE
ci: publish all the files from package.json/files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,11 @@ jobs:
       - run:
           name: Publish GitHub Pages
           command: |
-            npx gh-pages --dist . --message "chore: update to $(git rev-parse HEAD) [ci skip]" --repo "$(node -e 'process.stdout.write(require("./package.json").repository.url)')" --src '{{coverage,dist,docs,examples}/**/*,LICENSE*,*.{html,md}}'
+            npx gh-pages \
+              --dist . \
+              --message "chore: update to $(git rev-parse HEAD) [ci skip]" \
+              --repo "$(node -e 'process.stdout.write(require("./package.json").repository.url)')" \
+              --src "{{coverage,docs,examples,$(node -e 'process.stdout.write(require("./package.json").files.join(","))')}/**/*,*.{html,md}}"
 
   release:
     executor: node


### PR DESCRIPTION
This should finally close #183 for good.

It uses the files property from package.json to ensure that we have a single source of truth listing all the dist files that should be published on both npm and GitHub Pages.