### PR TITLE
docs(DOT): fix an error and clarify

### DIFF
--- a/docs/network/index.html
+++ b/docs/network/index.html
@@ -1708,10 +1708,11 @@ var network = new vis.Network(container, data);
         <p>
             Network supports data in the
             <a href="http://en.wikipedia.org/wiki/DOT_language" target="_blank">DOT language</a>.
-            To use data in the DOT language, you can use the vis.convertDOTNetwork converter to transform the DOT
-            language
-            into a vis.Network compatible nodes, edges and options objects. You can extend the options object with other
-            options if you'd like.
+            To use data in the DOT language, you can use the
+            vis.parseDOTNetwork converter function to transform the DOT
+            language string into a Vis Network compatible nodes, edges and
+            options. You can alter or extend the returned nodes, edges and
+            options if you like.
         </p>
 
         <p>
@@ -1721,7 +1722,7 @@ var network = new vis.Network(container, data);
 <pre class="prettyprint lang-js">
 // provide data in the DOT language
 var DOTstring = 'dinetwork {1 -> 1 -> 2; 2 -> 3; 2 -- 4; 2 -> 1 }';
-var parsedData = vis.convertDOTNetwork(DOTstring);
+var parsedData = vis.parseDOTNetwork(DOTstring);
 
 var data = {
   nodes: parsedData.nodes,


### PR DESCRIPTION
There was an error in this which used the legacy property name as a name of the export (legacy: `vis.network.convertDOTNetwork`, new: `vis.parseDOTNetwork`, docs: `vis.convertDOTNetwork`).

Also the text was rewritten to clarify it's meaning as the original formulation was quite ambitious.

Closes #214.