### PR TITLE
feat(build): add index files to bundles

### DIFF
--- a/dev-lib/bundle-css.d.ts
+++ b/dev-lib/bundle-css.d.ts
@@ -1,0 +1,1 @@
+import "./vis-network.css";

--- a/dev-lib/bundle-esm-index.d.ts
+++ b/dev-lib/bundle-esm-index.d.ts
@@ -1,0 +1,1 @@
+export * from "./esm";

--- a/dev-lib/bundle-vis-network-index.d.ts
+++ b/dev-lib/bundle-vis-network-index.d.ts
@@ -1,0 +1,1 @@
+export * from "./vis-network";

--- a/rollup.build.js
+++ b/rollup.build.js
@@ -80,6 +80,46 @@ export default [].concat.apply(
                     src: `./dev-lib/bundle-${variant}.d.ts`,
                     dest: ".",
                     rename: umdFileWithoutExt + ".d.ts"
+                  },
+                  {
+                    src: "./dev-lib/bundle-esm-index.d.ts",
+                    dest: ".",
+                    rename: `${variant}/index.d.ts`
+                  },
+                  {
+                    src: "./dev-lib/bundle-esm-index.d.ts",
+                    dest: ".",
+                    rename: `${variant}/index.js`
+                  },
+                  {
+                    src: "./dev-lib/bundle-vis-network-index.d.ts",
+                    dest: ".",
+                    rename: `${variant}/esm/index.d.ts`
+                  },
+                  {
+                    src: "./dev-lib/bundle-vis-network-index.d.ts",
+                    dest: ".",
+                    rename: `${variant}/esm/index.js`
+                  },
+                  {
+                    src: "./dev-lib/bundle-vis-network-index.d.ts",
+                    dest: ".",
+                    rename: `${variant}/umd/index.d.ts`
+                  },
+                  {
+                    src: "./dev-lib/bundle-vis-network-index.d.ts",
+                    dest: ".",
+                    rename: `${variant}/umd/index.js`
+                  },
+                  {
+                    src: "./dev-lib/bundle-css.d.ts",
+                    dest: ".",
+                    rename: "styles/index.d.ts"
+                  },
+                  {
+                    src: "./dev-lib/bundle-css.d.ts",
+                    dest: ".",
+                    rename: "styles/index.js"
                   }
                 ]
               }),


### PR DESCRIPTION
This allows more visually appealing imports when used with bundlers:
```typescript
// Old, but still works:
import * as vis from "vis-network/standalone/esm/vis-network";

// New, achieving the same result (ESM):
import * as vis from "vis-network/standalone";

// ESM explicitly:
import * as vis from "vis-network/standalone/esm";

// UMD explicitly:
import * as vis from "vis-network/standalone/umd";
```

This partially works in HTML but the old way is preferred (less requests,
library name in dev tools and better compatibility):
```html
<!-- Old, still works. Recommended. -->
<script
  type="text/javascript"
  src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"
></script>

<!-- New, works but has issues. Not recommended. -->
<script
  type="module"
  src="https://unpkg.com/vis-network/standalone/esm"
></script>

<!-- New, doesn't work. -->
<script
  type="text/javascript"
  src="https://unpkg.com/vis-network/standalone/umd"
></script>
```