### PR TITLE
example(arrow-alignment): add self ref alignment

### DIFF
--- a/examples/network/edgeStyles/arrowAlignment.html
+++ b/examples/network/edgeStyles/arrowAlignment.html
@@ -66,13 +66,25 @@
             id: 10 * i + 1,
             label: type,
             x: 0,
-            y: i * 50
+            y: i * 60
           },
           {
             id: 10 * i + 2,
             label: type,
             x: 800,
-            y: i * 50
+            y: i * 60
+          },
+          {
+            id: 10 * i + 3,
+            label: type,
+            x: 1000,
+            y: i * 60
+          },
+          {
+            id: 10 * i + 4,
+            label: type,
+            x: 1200 + (i % 5) * 250,
+            y: 200 + Math.floor(i / 5) * 5 * 50
           }
         ]);
         edges.add([
@@ -80,6 +92,27 @@
             from: 10 * i + 1,
             to: 10 * i + 2,
             smooth: { type },
+            arrows: {
+              from: { enabled: true, scaleFactor },
+              middle: { enabled: true, scaleFactor },
+              to: { enabled: true, scaleFactor }
+            }
+          },
+          {
+            from: 10 * i + 3,
+            to: 10 * i + 3,
+            smooth: { type },
+            arrows: {
+              from: { enabled: true, scaleFactor },
+              middle: { enabled: true, scaleFactor },
+              to: { enabled: true, scaleFactor }
+            }
+          },
+          {
+            from: 10 * i + 4,
+            to: 10 * i + 4,
+            smooth: { type },
+            selfReferenceSize: 100,
             arrows: {
               from: { enabled: true, scaleFactor },
               middle: { enabled: true, scaleFactor },


### PR DESCRIPTION
This demostrates #229. The arrows are visibly misaligned when the self reference circle is bigger than default. They are misaligned all the time actually but it's not really visible with smaller circumference.

![Screenshot from 2019-11-12 19-04-37](https://user-images.githubusercontent.com/12966757/68697555-5ac3fa80-057f-11ea-95fb-354b0f495a0e.png)
