### PR TITLE
fix(data-set): do not use private props

### DIFF
--- a/lib/network/modules/EdgesHandler.js
+++ b/lib/network/modules/EdgesHandler.js
@@ -137,7 +137,7 @@ class EdgesHandler {
       for (let edgeId in this.body.edges) {
         if (this.body.edges.hasOwnProperty(edgeId)) {
           let edge = this.body.edges[edgeId];
-          let edgeData = this.body.data.edges._data[edgeId];
+          const edgeData = this.body.data.edges.get(edgeId);
 
           // only forcibly remove the smooth curve if the data has been set of the edge has the smooth curves defined.
           // this is because a change in the global would not affect these curves.
@@ -370,7 +370,7 @@ class EdgesHandler {
    */
   refresh() {
     util.forEach(this.body.edges, (edge, edgeId) => {
-      let data = this.body.data.edges._data[edgeId];
+      const data = this.body.data.edges.get(edgeId);
       if (data !== undefined) {
         edge.setOptions(data);
       }

--- a/lib/network/modules/ManipulationSystem.js
+++ b/lib/network/modules/ManipulationSystem.js
@@ -1231,7 +1231,12 @@ class ManipulationSystem {
    * @private
    */
   _performEditEdge(sourceNodeId, targetNodeId) {
-    let defaultData = {id: this.edgeBeingEditedId, from: sourceNodeId, to: targetNodeId, label: this.body.data.edges._data[this.edgeBeingEditedId].label };
+    const defaultData = {
+      id: this.edgeBeingEditedId,
+      from: sourceNodeId,
+      to: targetNodeId,
+      label: this.body.data.edges.get(this.edgeBeingEditedId).label
+    };
     let eeFunct = this.options.editEdge;
     if (typeof eeFunct === 'object') {
       eeFunct = eeFunct.editWithoutDrag;

--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -419,17 +419,20 @@ class NodesHandler {
    */
   storePositions() {
     // todo: add support for clusters and hierarchical.
-    let dataArray = [];
-    var dataset = this.body.data.nodes.getDataSet();
+    const dataArray = [];
+    const dataset = this.body.data.nodes.getDataSet();
 
-    for (let nodeId in dataset._data) {
-      if (dataset._data.hasOwnProperty(nodeId)) {
-        let node = this.body.nodes[nodeId];
-        if (dataset._data[nodeId].x != Math.round(node.x) || dataset._data[nodeId].y != Math.round(node.y)) {
-          dataArray.push({ id: node.id, x: Math.round(node.x), y: Math.round(node.y) });
-        }
+    for (const dsNode of dataset.get()) {
+      const id = dsNode.id;
+      const bodyNode = this.body.nodes[id];
+      const x = Math.round(bodyNode.x);
+      const y = Math.round(bodyNode.y);
+
+      if (dsNode.x !== x || dsNode.y !== y) {
+        dataArray.push({ id, x, y });
       }
     }
+
     dataset.update(dataArray);
   }
 


### PR DESCRIPTION
Formerly DataSet._data was accessed directly. No idea how that could ever work at all. Now the proper methods from the API are used so there should be no further issues.

Closes #228.