### PR TITLE
fix(build): resolve compatibility issues with IE11

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,10 @@
     [
       "@babel/preset-env",
       {
-        "targets": "> 0.1% or not dead",
+        "targets": {
+          "browsers": "> 0.1% or not dead",
+          "esmodules": false
+        },
         "useBuiltIns": false
       }
     ],

--- a/.babelrc
+++ b/.babelrc
@@ -20,10 +20,7 @@
       }
     ]
   ],
-  "exclude": [
-    "node_modules/@babel/runtime-corejs3/**",
-    "node_modules/core-js-pure/**"
-  ],
+  "exclude": ["**/node_modules/**"],
   "env": {
     "test": {
       "presets": [
@@ -32,8 +29,7 @@
           {
             "targets": "maintained node versions"
           }
-        ],
-        "@babel/preset-typescript"
+        ]
       ]
     },
     "test-cov": {
@@ -43,8 +39,7 @@
           {
             "targets": "maintained node versions"
           }
-        ],
-        "@babel/preset-typescript"
+        ]
       ],
       "plugins": ["istanbul"]
     }


### PR DESCRIPTION
This should finally resolve the issues with IE11. Long story short we were polyfilling polyfills which resulted in all kinds of weird issues. This PR makes all bundles IE11 compatible so there's no need to transpile them anymore. Everything can be simply bundled and should work without issues. It should also somewhat reduce bundle size as there will be only a single layer of polyfilling done.

Dependency updates (visjs/vis-util#68, visjs/vis-data#35) will be necessary before all problems (#166) will be solved.