### PR TITLE
fix(edges-handler): do not access props on null

### DIFF
--- a/lib/network/modules/EdgesHandler.js
+++ b/lib/network/modules/EdgesHandler.js
@@ -141,7 +141,7 @@ class EdgesHandler {
 
           // only forcibly remove the smooth curve if the data has been set of the edge has the smooth curves defined.
           // this is because a change in the global would not affect these curves.
-          if (edgeData !== undefined) {
+          if (edgeData != null) {
             let smoothOptions = edgeData.smooth;
             if (smoothOptions !== undefined) {
               if (smoothOptions.enabled === true && smoothOptions.type === 'dynamic') {


### PR DESCRIPTION
Data set docs: `Item | null`.
Data set implementation today: `Item | null`.
Data set implementation 5 years ago: `Item | null`.
EdgesHandler.js for the past 5 years:
```javascript
if (item !== undefined) {
    item[prop]
}
```

I have no idea why no one noticed this for five years. It either got the
item from the data set or accessed a property on null and crashed.

PS: This has been introduced by a commit saying "updated docs".