### PR TITLE
chore(examples): fix peer build example

### DIFF
--- a/examples/network/basic_usage/peer.html
+++ b/examples/network/basic_usage/peer.html
@@ -36,8 +36,14 @@
       }
     </style>
 
-    <script type="text/javascript" src="https://unpkg.com/vis-util@latest"></script>
-    <script type="text/javascript" src="https://unpkg.com/vis-data@latest"></script>
+    <script
+      type="text/javascript"
+      src="https://unpkg.com/vis-util@latest"
+    ></script>
+    <script
+      type="text/javascript"
+      src="https://unpkg.com/vis-data@latest"
+    ></script>
     <script
       type="text/javascript"
       src="../../../peer/umd/vis-network.js"
@@ -108,6 +114,7 @@
 &lt;link rel=&quot;stylesheet&quot; type=&quot;text/css&quot; href=&quot;https://unpkg.com/vis-network/styles/vis-network.min.css&quot; /&gt;
 &lt;!-- You may include other packages like Vis Timeline or Vis Graph3D here. --&gt;
 
+&lt;div id=&quot;mynetwork&quot;&gt;&lt;/div&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
   // create an array with nodes
   var nodes = new vis.DataSet([
@@ -170,6 +177,12 @@ const data = {
 };
 const options = {};
 const network = new Network(container, data, options);
+      </code></pre>
+
+      The code above has to be injected into a page which contains an element
+      with <code>mynetwork</code> id. Like for example:
+      <pre><code>
+&lt;div id=&quot;mynetwork&quot;&gt;&lt;/div&gt;
       </code></pre>
     </div>
 

--- a/examples/network/basic_usage/peer.html
+++ b/examples/network/basic_usage/peer.html
@@ -36,8 +36,8 @@
       }
     </style>
 
-    <script type="text/javascript" src="https://unpkg.com/vis-util"></script>
-    <script type="text/javascript" src="https://unpkg.com/vis-data"></script>
+    <script type="text/javascript" src="https://unpkg.com/vis-util@latest"></script>
+    <script type="text/javascript" src="https://unpkg.com/vis-data@latest"></script>
     <script
       type="text/javascript"
       src="../../../peer/umd/vis-network.js"
@@ -97,9 +97,9 @@
 
       <h5>Browser UMD</h5>
       <pre><code>
-&lt;script type=&quot;text/javascript&quot; src=&quot;https://unpkg.com/vis-util/peer/umd/vis-util.min.js&quot;&gt;&lt;/script&gt;
-&lt;script type=&quot;text/javascript&quot; src=&quot;https://unpkg.com/vis-data/peer/umd/vis-data.min.js&quot;&gt;&lt;/script&gt;
-&lt;script type=&quot;text/javascript&quot; src=&quot;https://unpkg.com/vis-network/peer/umd/vis-network.min.js&quot;&gt;&lt;/script&gt;
+&lt;script type=&quot;text/javascript&quot; src=&quot;https://unpkg.com/vis-util&commat;latest&quot;&gt;&lt;/script&gt;
+&lt;script type=&quot;text/javascript&quot; src=&quot;https://unpkg.com/vis-data&commat;latest&quot;&gt;&lt;/script&gt;
+&lt;script type=&quot;text/javascript&quot; src=&quot;https://unpkg.com/vis-network&commat;latest/peer/umd/vis-network.min.js&quot;&gt;&lt;/script&gt;
 &lt;link rel=&quot;stylesheet&quot; type=&quot;text/css&quot; href=&quot;https://unpkg.com/vis-network/styles/vis-network.min.css&quot; /&gt;
 &lt;!-- You may include other packages like Vis Timeline or Vis Graph3D here. --&gt;
 
@@ -135,7 +135,7 @@
 
       <h5>Bundled ESM</h5>
       <pre><code>
-import { DataSet } from "vis-data/peer/esm/vis-data";
+import { DataSet } from "vis-data";
 import { Network } from "vis-network/peer/esm/vis-network";
 import "vis-network/styles/vis-network.css";
 

--- a/examples/network/basic_usage/peer.html
+++ b/examples/network/basic_usage/peer.html
@@ -97,6 +97,11 @@
 
       <h5>Browser UMD</h5>
       <pre><code>
+&lt;!--
+  In the following URLs you may want to replace &commat;latest by &commat;version
+  to prevent unexpected potentionally breaking updates.
+  For example vis-data&commat;1.0.0 instead of vis-data&commat;latest.
+--&gt;
 &lt;script type=&quot;text/javascript&quot; src=&quot;https://unpkg.com/vis-util&commat;latest&quot;&gt;&lt;/script&gt;
 &lt;script type=&quot;text/javascript&quot; src=&quot;https://unpkg.com/vis-data&commat;latest&quot;&gt;&lt;/script&gt;
 &lt;script type=&quot;text/javascript&quot; src=&quot;https://unpkg.com/vis-network&commat;latest/peer/umd/vis-network.min.js&quot;&gt;&lt;/script&gt;


### PR DESCRIPTION
This now advises people to import files that actually exists and there's a little note added about version pinning on unpkg.com. It also includes `<div id="mynetwork"/>` as to make it explicit to people that it's necessary.

- Closes #278.