### PR TITLE
test(e2e): add directed hierarchical layout test

### DIFF
--- a/cypress/integration/directed-hierarchical-layout.spec.ts
+++ b/cypress/integration/directed-hierarchical-layout.spec.ts
@@ -1,0 +1,324 @@
+import { IdType, TestData, addMoreEdges, generateMaryTree } from "./helpers";
+
+/**
+ * Generate a consecutive list of ids starting with first and ending with last
+ * including both.
+ *
+ * @param first - Number of the first id to generate.
+ * @param last - Number of the last id to generate.
+ *
+ * @returns An array of ids for example `"node0"` or `"node789"`.
+ */
+function nodeIdRange(first: number, last: number): IdType[] {
+  return new Array(1 + last - first)
+    .fill(null)
+    .map((_, i): IdType => `node${first + i}`);
+}
+
+describe("Directed hierarchical layout", (): void => {
+  const configs: {
+    /**
+     * The name that will be displayed by Cypress for given test.
+     */
+    name: string;
+    /**
+     * Data in the same format as in `new Network(container, data, options);`.
+     */
+    data: TestData;
+    /**
+     * Each member of this list clusters more nodes. Swallows edges refers to
+     * how many edges disappear from the network thanks to the newly created
+     * cluster.
+     *
+     * @remarks The result of this is accumulated. For example for three lists
+     * of node ids four tests will be run: One with no clusters, one with first
+     * cluster, one with first and second and one with first through third
+     * clusters.
+     */
+    clusterConfigs?: { nodes: IdType[]; swallowsEdges: number }[];
+    /**
+     * This skips some checks that just can't be passed by a cyclic graph.
+     */
+    cyclic: boolean;
+  }[] = [
+    {
+      name: "Binary tree",
+      data: generateMaryTree(63, 2),
+      clusterConfigs: [{ nodes: nodeIdRange(3, 6), swallowsEdges: 2 }],
+      cyclic: false
+    },
+    {
+      name: "5-ary tree",
+      data: generateMaryTree(156, 5),
+      clusterConfigs: [
+        {
+          nodes: [
+            ...nodeIdRange(2, 3),
+            ...nodeIdRange(11, 20),
+            ...nodeIdRange(56, 105)
+          ],
+          swallowsEdges: 61
+        }
+      ],
+      cyclic: false
+    },
+    {
+      name: "Acyclic graph",
+      data: addMoreEdges(generateMaryTree(63, 2)),
+      clusterConfigs: [
+        {
+          nodes: [
+            ...nodeIdRange(2, 3),
+            ...nodeIdRange(11, 20),
+            ...nodeIdRange(56, 62)
+          ],
+          swallowsEdges: 31
+        }
+      ],
+      cyclic: false
+    },
+    {
+      name: "Cyclic graph (2 nodes)",
+      data: {
+        nodes: [
+          { id: "node0", label: "Node #0" },
+          { id: "node1", label: "Node #1" }
+        ],
+        edges: [
+          { id: "edge_node0-node1", from: "node0", to: "node1" },
+          { id: "edge_node1-node0", from: "node1", to: "node0" }
+        ]
+      },
+      cyclic: true
+    },
+    {
+      name: "Cyclic graph (10 nodes)",
+      data: {
+        nodes: [
+          { id: "node0", label: "Node #0" },
+          { id: "node1", label: "Node #1" },
+          { id: "node2", label: "Node #2" },
+          { id: "node3", label: "Node #3" },
+          { id: "node4", label: "Node #4" },
+          { id: "node5", label: "Node #5" },
+          { id: "node6", label: "Node #6" },
+          { id: "node7", label: "Node #7" },
+          { id: "node8", label: "Node #8" },
+          { id: "node9", label: "Node #9" }
+        ],
+        edges: [
+          { id: "edge_node1-node0", from: "node1", to: "node0" },
+          { id: "edge_node0-node1", from: "node0", to: "node1" },
+          { id: "edge_node1-node2", from: "node1", to: "node2" },
+          { id: "edge_node2-node3", from: "node2", to: "node3" },
+          { id: "edge_node3-node4", from: "node3", to: "node4" },
+          { id: "edge_node4-node5", from: "node4", to: "node5" },
+          { id: "edge_node5-node6", from: "node5", to: "node6" },
+          { id: "edge_node6-node7", from: "node6", to: "node7" },
+          { id: "edge_node7-node8", from: "node7", to: "node8" },
+          { id: "edge_node8-node9", from: "node8", to: "node9" }
+        ]
+      },
+      cyclic: true
+    },
+    {
+      name: "Linear",
+      data: {
+        nodes: [
+          { id: "node0", label: "Node #0" },
+          { id: "node1", label: "Node #1" },
+          { id: "node2", label: "Node #2" },
+          { id: "node3", label: "Node #3" },
+          { id: "node4", label: "Node #4" },
+          { id: "node5", label: "Node #5" },
+          { id: "node6", label: "Node #6" },
+          { id: "node7", label: "Node #7" },
+          { id: "node8", label: "Node #8" },
+          { id: "node9", label: "Node #9" }
+        ],
+        edges: [
+          { id: "edge_node0-node1", from: "node0", to: "node1" },
+          { id: "edge_node1-node2", from: "node1", to: "node2" },
+          { id: "edge_node2-node3", from: "node2", to: "node3" },
+          { id: "edge_node3-node4", from: "node3", to: "node4" },
+          { id: "edge_node4-node5", from: "node4", to: "node5" },
+          { id: "edge_node5-node6", from: "node5", to: "node6" },
+          { id: "edge_node6-node7", from: "node6", to: "node7" },
+          { id: "edge_node7-node8", from: "node7", to: "node8" },
+          { id: "edge_node8-node9", from: "node8", to: "node9" }
+        ]
+      },
+      clusterConfigs: [
+        { nodes: ["node1"], swallowsEdges: 0 },
+        { nodes: ["node2", "node3"], swallowsEdges: 1 },
+        { nodes: ["node6", "node7", "node8"], swallowsEdges: 2 }
+      ],
+      cyclic: false
+    }
+  ];
+
+  configs.forEach(({ clusterConfigs, cyclic, data, name }): void => {
+    const configs = [
+      { nodes: [], swallowsEdges: 0 },
+      ...(clusterConfigs || [])
+    ].map(({ nodes }, i, arr): {
+      expectedVisibleEdges: number;
+      nodesToCluster: Set<IdType>;
+    } => ({
+      expectedVisibleEdges:
+        data.edges.length -
+        arr
+          .slice(0, i + 1)
+          .reduce((acc, { swallowsEdges }): number => acc + swallowsEdges, 0),
+      nodesToCluster: new Set(nodes)
+    }));
+
+    describe(name, (): void => {
+      it("Preparation", (): void => {
+        cy.visit("http://localhost:58253/cypress/pages/universal.html");
+
+        cy.visRunCode(({ network, nodes, edges }): void => {
+          network.setOptions({
+            edges: {
+              arrows: {
+                to: true
+              }
+            },
+            layout: {
+              hierarchical: {
+                enabled: true,
+                sortMethod: "directed"
+              }
+            }
+          });
+
+          nodes.add(data.nodes);
+          edges.add(data.edges);
+        });
+      });
+
+      configs.forEach(({ expectedVisibleEdges, nodesToCluster }, cid): void => {
+        const clusterDescribeName =
+          cid === 0 ? "Without clustering" : `With ${cid} clusters`;
+
+        describe(clusterDescribeName, (): void => {
+          if (cid > 0) {
+            it("Cluster", (): void => {
+              cy.visRunCode(({ network }): void => {
+                network.cluster({
+                  clusterNodeProperties: {
+                    label: `Cluster #${cid}`
+                  },
+                  joinCondition: ({ id }): boolean => nodesToCluster.has(id)
+                });
+              });
+            });
+          }
+
+          /*
+           * There's no point in testing running this test for cyclic graphs.
+           * Such graphs are always invalid.
+           */
+          if (!cyclic) {
+            /**
+             * Test that children are placed below their parents and parents
+             * above their children.
+             *
+             * This also tests that the required number of edges is visible on
+             * the canvas. Since the number is available there anyway, it can as
+             * well be tested.
+             */
+            it("Hierarchical order of nodes", (): void => {
+              cy.visRunCode(({ network }): void => {
+                const visibleNodeIds = new Set(
+                  Object.keys(network.getPositions())
+                );
+
+                /*
+                 * No matter how much ESLint think they're unnecessary, these two
+                 * assertions are indeed necessary.
+                 */
+                // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+                const visibleEdges = (Object.values(
+                  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+                  (network as any).body.edges
+                ) as any[]).filter(
+                  (edge): boolean =>
+                    visibleNodeIds.has(edge.fromId) &&
+                    visibleNodeIds.has(edge.toId)
+                );
+
+                const invalidEdges = visibleEdges
+                  .map(({ fromId, toId }): {
+                    fromId: IdType;
+                    fromPosition: Point;
+                    toId: IdType;
+                    toPosition: Point;
+                  } => ({
+                    fromId,
+                    fromPosition: network.getPositions([fromId])[fromId],
+                    toId,
+                    toPosition: network.getPositions([toId])[toId]
+                  }))
+                  .filter(({ fromPosition, toPosition }): boolean => {
+                    return !(fromPosition.y < toPosition.y);
+                  });
+
+                expect(invalidEdges).to.deep.equal([]);
+                expect(visibleEdges).to.have.lengthOf(expectedVisibleEdges);
+              });
+            });
+
+            /**
+             * Test that all levels are evenly spaced without gaps.
+             */
+            it("Spacing between levels", (): void => {
+              cy.visRunCode(({ network }): void => {
+                const levels = Array.from(
+                  new Set(
+                    Object.values(network.getPositions()).map(
+                      ({ y }): number => y
+                    )
+                  )
+                ).sort((a, b): number => a - b);
+
+                const gaps = new Array(levels.length - 1)
+                  .fill(null)
+                  .map((_, i): number => {
+                    return levels[i] - levels[i + 1];
+                  });
+
+                expect(
+                  gaps.every((gap, _i, arr): boolean => {
+                    return gap === arr[0];
+                  }),
+                  "All levels should be evenly spaced without gaps."
+                ).to.be.true;
+              });
+            });
+          }
+
+          /**
+           * Click through the entire network to ensure that:
+           *   - No node is off the canvas.
+           *   - No node is covered behind another node.
+           *   - Each node is selected after being clicked.
+           */
+          it("Click through the network", (): void => {
+            cy.visStabilizeFitAndRunCode(({ network }): void => {
+              network.unselectAll();
+              expect(network.getSelectedNodes()).to.deep.equal([]);
+
+              const visibleNodeIds = new Set(
+                Object.keys(network.getPositions())
+              );
+              visibleNodeIds.forEach((id): void => {
+                cy.visClickNode(id);
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/cypress/integration/helpers/common.ts
+++ b/cypress/integration/helpers/common.ts
@@ -1,0 +1,5 @@
+export * from "../../../standalone";
+
+import { Edge, Node } from "../../../standalone";
+
+export type TestData = { nodes: Node[]; edges: Edge[] };

--- a/cypress/integration/helpers/index.ts
+++ b/cypress/integration/helpers/index.ts
@@ -1,0 +1,2 @@
+export * from "./common";
+export * from "./trees";

--- a/cypress/integration/helpers/trees.ts
+++ b/cypress/integration/helpers/trees.ts
@@ -1,0 +1,67 @@
+import { Edge, Node, TestData } from "./common";
+
+/**
+ * Generate m-ary tree with given amount of nodes. The nodes have ids
+ * `"node${nm}"` where nm is a number sturting from 0 which is the root of the
+ * tree and increasing by one with each node in top to bottom left to right
+ * direction.
+ *
+ * @param amount - The amount of nodes in the tree.
+ * @param m - The maximum amount of child nodes per parent node.
+ *
+ * @returns Nodes and edges that can be directly supplied to Vis Network.
+ */
+export function generateMaryTree(amount: number = 63, m: number = 2): TestData {
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+
+  const node0 = { id: "node0", label: "Node #0" };
+  nodes.push(node0);
+
+  for (let i = 1; i < amount; ++i) {
+    const id = `node${i}`;
+    const parentNode = nodes[Math.floor((i - 1) / m)];
+    const parentId = parentNode.id!;
+
+    const node = { id, label: `Node #${i}` };
+    nodes.push(node);
+    edges.push({
+      id: `edge_${parentId}-${id}`,
+      label: `${parentId} - ${id}`,
+      from: parentId,
+      to: id
+    });
+  }
+
+  return { nodes, edges };
+}
+
+/**
+ * Take existing data and put more edges between the nodes. If used on the
+ * output of `generateMaryTree` it gets turned into acyclic graph.
+ *
+ * @param data - The data to be altered.
+ *
+ * @returns The same objects as the argument data.
+ */
+export function addMoreEdges(data: TestData): TestData {
+  const nodes = data.nodes;
+  const edges = data.edges;
+
+  for (let i = 1; i < nodes.length; ++i) {
+    if (i % 2 === 0) {
+      const id = nodes[i].id;
+      const parentNode = nodes[Math.floor((i - 1) / 3)];
+      const parentId = parentNode.id!;
+
+      edges.push({
+        id: `edge2_${parentId}-${id}`,
+        label: `${parentId} - ${id}`,
+        from: parentId,
+        to: id
+      });
+    }
+  }
+
+  return data;
+}

--- a/cypress/pages/universal.html
+++ b/cypress/pages/universal.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Vis Network | Cypress | Universal</title>
+
+    <style type="text/css">
+      html,
+      body,
+      #mynetwork {
+        background: white;
+        height: 100%;
+        margin: 0px;
+        padding: 0px;
+        width: 100%;
+      }
+    </style>
+
+    <script
+      type="text/javascript"
+      src="../../standalone/umd/vis-network.js"
+    ></script>
+  </head>
+
+  <body>
+    <div id="mynetwork"></div>
+    <script type="text/javascript">
+      /*
+       * Create a network
+       */
+      const container = document.getElementById("mynetwork");
+      const nodes = new vis.DataSet();
+      const edges = new vis.DataSet();
+      const data = { nodes, edges };
+      const options = {
+        physics: false
+      };
+      const network = new vis.Network(container, data, options);
+
+      /*
+       * Expose the variables for test specs.
+       */
+      window.edges = edges;
+      window.nodes = nodes;
+      window.network = network;
+    </script>
+  </body>
+</html>

--- a/cypress/support/access-globals.ts
+++ b/cypress/support/access-globals.ts
@@ -1,0 +1,95 @@
+import {
+  DataSetEdges,
+  DataSetNodes,
+  Network
+} from "../../declarations/index-standalone";
+
+interface RunCodeProps {
+  edges: DataSetEdges;
+  network: Network;
+  nodes: DataSetNodes;
+}
+
+declare global {
+  interface Point {
+    x: number;
+    y: number;
+  }
+
+  // eslint-disable-next-line no-redeclare
+  namespace Cypress {
+    interface Chainable<Subject> {
+      /**
+       * Runs custom code with the network instance and data sets available.
+       *
+       * @param callback - The callback that will be executed within
+       * `cy.window().then` environment.
+       */
+      visRunCode<S>(callback: (props: RunCodeProps) => void): Chainable<S>;
+
+      /**
+       * Runs custom code with the network instance and data sets available
+       * after it has been stabilized and fitted.
+       *
+       * @param callback - The callback that will be executed within
+       * `cy.window().then` environment.
+       */
+      visStabilizeFitAndRunCode<S>(
+        callback: (props: RunCodeProps) => void
+      ): Chainable<S>;
+    }
+  }
+}
+
+// eslint-disable-next-line require-jsdoc
+export function visRunCode(callback: (props: RunCodeProps) => void): void {
+  cy.window().then(({ edges, network, nodes }: any): void => {
+    if (edges && network && nodes) {
+      callback({ edges, network, nodes });
+    } else {
+      throw new Error("No page globals were found.");
+    }
+  });
+}
+Cypress.Commands.add("visRunCode", visRunCode);
+
+// eslint-disable-next-line require-jsdoc
+export function visStabilizeFitAndRunCode(
+  callback: (props: RunCodeProps) => void
+): void {
+  cy.window().then(
+    async ({ edges, network, nodes }: any): Promise<void> => {
+      if (edges && network && nodes) {
+        /*
+         * Wait for the network to stabilize.
+         */
+        await new Promise((resolve): void => {
+          network.once("stabilized", resolve);
+          network.stabilize();
+        });
+
+        /*
+         * Wait for the network to be fitted into the viewport.
+         *
+         * The purpose of the animation is to fire an event when everything is
+         * done. Whithout the animation there is no way of knowing when it's
+         * actually done and Cypress will just error out immediately.
+         */
+        await new Promise((resolve): void => {
+          network.once("animationFinished", resolve);
+          network.fit({
+            animation: {
+              duration: 1000,
+              easingFunction: "linear"
+            }
+          });
+        });
+
+        callback({ edges, network, nodes });
+      } else {
+        throw new Error("No page globals were found.");
+      }
+    }
+  );
+}
+Cypress.Commands.add("visStabilizeFitAndRunCode", visStabilizeFitAndRunCode);

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,3 +1,7 @@
+import { IdType } from "../../declarations/index-standalone";
+
+export * from "./access-globals";
+
 declare global {
   interface Point {
     x: number;
@@ -6,14 +10,14 @@ declare global {
 
   // eslint-disable-next-line no-redeclare
   namespace Cypress {
-    interface Chainable {
+    interface Chainable<Subject> {
       /**
        * Place a new node on the canvas.
        *
        * @param x - DOM x coord.
        * @param y - DOM y coord.
        */
-      visPlaceNode(x: number, y: number): void;
+      visPlaceNode(x: number, y: number): Chainable<Subject>;
 
       /**
        * Connect nodes at given positions with a new edge.
@@ -21,7 +25,28 @@ declare global {
        * @param from - DOM from node coords.
        * @param to - DOM to node coords.
        */
-      visConnectNodes(from: Point, to: Point): void;
+      visConnectNodes(from: Point, to: Point): Chainable<Subject>;
+
+      /**
+       * Click a node based on given node id.
+       * Fails if the node doesn't end up in the selection.
+       *
+       * @param id - Id of the node to be clicked.
+       */
+      visClickNode(id: IdType): Chainable<Subject>;
+
+      /**
+       * Click an edge based on given edge id.
+       * Fails if the edge doesn't end up in the selection.
+       *
+       * @param id - Id of the edge to be clicked.
+       */
+      visClickEdge(id: IdType): Chainable<Subject>;
+
+      /**
+       * Stabilizes and fits the network.
+       */
+      visStabilizeAndFit(): Chainable<Subject>;
     }
   }
 }
@@ -85,3 +110,77 @@ export function visConnectNodes(from: Point, to: Point): void {
   cy.get("#events .click .edge").should("have.length", 1);
 }
 Cypress.Commands.add("visConnectNodes", visConnectNodes);
+
+// eslint-disable-next-line require-jsdoc
+export function visClickNode(id: IdType): void {
+  cy.visRunCode(({ network }): void => {
+    const { x, y } = network.canvasToDOM(network.getPositions([id])[id]);
+    cy.get("#mynetwork canvas").click(x, y);
+    cy.visRunCode(({ network }): void => {
+      expect(
+        network.getSelectedNodes(),
+        "The node should be selected after it was clicked."
+      ).to.deep.equal([id]);
+    });
+  });
+}
+Cypress.Commands.add("visClickNode", visClickNode);
+
+// eslint-disable-next-line require-jsdoc
+export function visClickEdge(id: IdType): void {
+  cy.visRunCode(({ network }): void => {
+    const [fromId, toId] = network.getConnectedNodes(id) as IdType[];
+
+    const { x: x1, y: y1 } = network.canvasToDOM(
+      network.getPositions([fromId])[fromId]
+    );
+    const { x: x2, y: y2 } = network.canvasToDOM(
+      network.getPositions([toId])[toId]
+    );
+
+    const x = (x1 + x2) / 2;
+    const y = (y1 + y2) / 2;
+
+    cy.get("#mynetwork canvas").click(x, y);
+    cy.visRunCode(({ network }): void => {
+      expect(
+        network.getSelectedEdges(),
+        "The edge should be selected after it was clicked."
+      ).to.deep.equal([id]);
+    });
+  });
+}
+Cypress.Commands.add("visClickEdge", visClickEdge);
+
+// eslint-disable-next-line require-jsdoc
+export function visStabilizeAndFit(): void {
+  cy.visRunCode(
+    async ({ network }): Promise<void> => {
+      /*
+       * Wait for the network to stabilize.
+       */
+      await new Promise((resolve): void => {
+        network.once("stabilized", resolve);
+        network.stabilize();
+      });
+
+      /*
+       * Wait for the network to be fitted into the viewport.
+       *
+       * The purpose of the animation is to fire an event when everything is
+       * done. Whithout the animation there is no way of knowing when it's
+       * actually done and Cypress will just error out immediately.
+       */
+      await new Promise((resolve): void => {
+        network.once("animationFinished", resolve);
+        network.fit({
+          animation: {
+            duration: 1000,
+            easingFunction: "linear"
+          }
+        });
+      });
+    }
+  );
+}
+Cypress.Commands.add("visStabilizeAndFit", visStabilizeAndFit);


### PR DESCRIPTION
This tests whether all nodes are placed and clickable (after stabilize and fit), the correct number of edges connects the visible nodes and that levels are evenly spaced without gaps. All forementioned is tested again before and after clustering. The test checks linear graphs, trees and general acyclic graphs. Some tests are also performed agains simple cyclic graphs but that's mostly to just make sure the layouting algorithm doesn't cycle forever or something like that.

This commit comes with universal HTML page that exposes it's variables for the spec file to use and commands that can take advantage of this. The idea here is to be able to execute any code from the spec file without having to create a new HTML for it. This was created as a side effect but in the end it is probably way more useful than the test itself.

I tried the test against older versions of the library and it failed due to nodes being placed in wrong levels or gaps being created after clustering. In other words it detects regressions it is supposed to detect.