### PR TITLE
ci(gh-pages): include Korean docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,7 @@ jobs:
               --dist . \
               --message "chore: update to $(git rev-parse HEAD) [ci skip]" \
               --repo "$(node -e 'process.stdout.write(require("./package.json").repository.url)')" \
-              --src "{{common-docs-files,coverage,docs,examples,$(node -e 'process.stdout.write(require("./package.json").files.join(","))')}/**/*,*.{html,md}}"
+              --src "{{common-docs-files,coverage,docs,docs-kr,examples,$(node -e 'process.stdout.write(require("./package.json").files.join(","))')}/**/*,*.{html,md}}"
 
   release:
     executor: node


### PR DESCRIPTION
The directory was simply not copied over there which lead to fancy Korean flags pointing nowhere.