### PR TITLE
Fix labels in Chosen Elements example

### DIFF
--- a/examples/network/other/chosen.html
+++ b/examples/network/other/chosen.html
@@ -57,32 +57,32 @@
 
   var changeChosenLabelColor =
     function(ctx, values, id) {
-      values.color = "#ff0000";
+      ctx.color = "#ff0000";
     }
 
   var changeChosenLabelSize =
     function(ctx, values, id) {
-      values.size += 1;
+      ctx.size += 1;
     }
 
   var changeChosenLabelFace =
     function(ctx, values, id) {
-      values.face = "serif";
+      ctx.face = "serif";
     }
 
   var changeChosenLabelMod =
     function(ctx, values, id) {
-      values.mod = "bold italic";
+      ctx.mod = "bold italic";
     }
 
   var changeChosenLabelStrokeWidth =
     function(ctx, values, id) {
-      values.strokeWidth = 5;
+      ctx.strokeWidth = 5;
     }
 
   var changeChosenLabelStrokeColor =
     function(ctx, values, id) {
-      values.strokeColor = "#00ff00";
+      ctx.strokeColor = "#00ff00";
     }
 
   var changeChosenNodeColor =

--- a/examples/network/other/chosen.html
+++ b/examples/network/other/chosen.html
@@ -56,33 +56,33 @@
 <script type="text/javascript">
 
   var changeChosenLabelColor =
-    function(ctx, values, id) {
-      ctx.color = "#ff0000";
+    function(values, id, selected, hovering) {
+      values.color = "#ff0000";
     }
 
   var changeChosenLabelSize =
-    function(ctx, values, id) {
-      ctx.size += 1;
+    function(values, id, selected, hovering) {
+      values.size += 1;
     }
 
   var changeChosenLabelFace =
-    function(ctx, values, id) {
-      ctx.face = "serif";
+    function(values, id, selected, hovering) {
+      values.face = "serif";
     }
 
   var changeChosenLabelMod =
-    function(ctx, values, id) {
-      ctx.mod = "bold italic";
+    function(values, id, selected, hovering) {
+      values.mod = "bold italic";
     }
 
   var changeChosenLabelStrokeWidth =
-    function(ctx, values, id) {
-      ctx.strokeWidth = 5;
+    function(values, id, selected, hovering) {
+      values.strokeWidth = 5;
     }
 
   var changeChosenLabelStrokeColor =
-    function(ctx, values, id) {
-      ctx.strokeColor = "#00ff00";
+    function(values, id, selected, hovering) {
+      values.strokeColor = "#00ff00";
     }
 
   var changeChosenNodeColor =


### PR DESCRIPTION
The labels in the [Chosen Elements example](https://visjs.github.io/vis-network/examples/network/other/chosen.html) do not change on hover as they're supposed to. Using the `ctx` param instead of `values` when editing the properties fixes the problem.
