### PR TITLE
fix(network): add missing clustering methods

### DIFF
--- a/lib/network/Network.js
+++ b/lib/network/Network.js
@@ -496,6 +496,7 @@ Network.prototype.cluster             = function() {return this.clustering.clust
 Network.prototype.getNodesInCluster   = function() {return this.clustering.getNodesInCluster.apply(this.clustering,arguments);};
 Network.prototype.clusterByConnection = function() {return this.clustering.clusterByConnection.apply(this.clustering,arguments);};
 Network.prototype.clusterByHubsize    = function() {return this.clustering.clusterByHubsize.apply(this.clustering,arguments);};
+Network.prototype.updateClusteredNode = function() {return this.clustering.updateClusteredNode.apply(this.clustering,arguments);};
 
 /**
  * This method will cluster all nodes with 1 edge with their respective connected node.

--- a/lib/network/Network.js
+++ b/lib/network/Network.js
@@ -497,6 +497,10 @@ Network.prototype.getNodesInCluster   = function() {return this.clustering.getNo
 Network.prototype.clusterByConnection = function() {return this.clustering.clusterByConnection.apply(this.clustering,arguments);};
 Network.prototype.clusterByHubsize    = function() {return this.clustering.clusterByHubsize.apply(this.clustering,arguments);};
 Network.prototype.updateClusteredNode = function() {return this.clustering.updateClusteredNode.apply(this.clustering,arguments);};
+Network.prototype.getClusteredEdges   = function() {return this.clustering.getClusteredEdges.apply(this.clustering,arguments);};
+Network.prototype.getBaseEdge         = function() {return this.clustering.getBaseEdge.apply(this.clustering,arguments);};
+Network.prototype.getBaseEdges        = function() {return this.clustering.getBaseEdges.apply(this.clustering,arguments);};
+Network.prototype.updateEdge          = function() {return this.clustering.updateEdge.apply(this.clustering,arguments);};
 
 /**
  * This method will cluster all nodes with 1 edge with their respective connected node.

--- a/lib/network/modules/Clustering.js
+++ b/lib/network/modules/Clustering.js
@@ -897,7 +897,7 @@ class ClusterEngine {
 
   /**
   * Using a clustered nodeId, update with the new options
-  * @param {vis.Edge.id} clusteredNodeId
+  * @param {Node.id} clusteredNodeId
   * @param {object} newOptions
   */
   updateClusteredNode(clusteredNodeId, newOptions) {


### PR DESCRIPTION
This contribution was cherry picked from @Menighin's (thanks by the way) PR to the original @almende/vis repository.

These methods are in the docs and declarations but in reality they don't exist. Since they're well documented they probably should exist otherwise people are forced to use `network.clustering` which is an internal module that people shouldn't access directly.

Closes #338.