### PR TITLE
fix(view-fit): prevent potential NaN on zero sized canvas

### DIFF
--- a/lib/network/modules/View.js
+++ b/lib/network/modules/View.js
@@ -54,8 +54,19 @@ class View {
       options.nodes = this.body.nodeIndices;
     }
 
+    const canvasWidth = this.canvas.frame.canvas.clientWidth;
+    const canvasHeight = this.canvas.frame.canvas.clientHeight;
 
-    if (initialZoom === true) {
+    if (canvasWidth === 0 || canvasHeight === 0) {
+      // There's no point in trying to fit into zero sized canvas. This could
+      // potentially even result in invalid values being computed. For example
+      // for network without nodes and zero sized canvas the zoom level would
+      // end up being computed as 0/0 which results in NaN. In any other case
+      // this would be 0/something which is again pointless to compute.
+      zoomLevel = 1;
+
+      range = NetworkUtil.getRange(this.body.nodes, options.nodes);
+    } else if (initialZoom === true) {
       // check if more than half of the nodes have a predefined position. If so, we use the range, not the approximation.
       let positionDefined = 0;
       for (let nodeId in this.body.nodes) {
@@ -77,7 +88,7 @@ class View {
       zoomLevel = 12.662 / (numberOfNodes + 7.4147) + 0.0964822; // this is obtained from fitting a dataset from 5 points with scale levels that looked good.
 
       // correct for larger canvasses.
-      let factor = Math.min(this.canvas.frame.canvas.clientWidth / 600, this.canvas.frame.canvas.clientHeight / 600);
+      const factor = Math.min(canvasWidth / 600, canvasHeight / 600);
       zoomLevel *= factor;
     }
     else {
@@ -87,8 +98,8 @@ class View {
       let xDistance = Math.abs(range.maxX - range.minX) * 1.1;
       let yDistance = Math.abs(range.maxY - range.minY) * 1.1;
 
-      let xZoomLevel = this.canvas.frame.canvas.clientWidth  / xDistance;
-      let yZoomLevel = this.canvas.frame.canvas.clientHeight / yDistance;
+      const xZoomLevel = canvasWidth  / xDistance;
+      const yZoomLevel = canvasHeight / yDistance;
 
       zoomLevel = (xZoomLevel <= yZoomLevel) ? xZoomLevel : yZoomLevel;
     }


### PR DESCRIPTION
It's perfectly valid for the canvas element to have zero size. However without any nodes that would lead to 0/0 and subsequent NaN zoom level.

This change makes it to simply set zoom level to 1 in such a case.