### PR TITLE
fix(canvas): don't set camera state with zero height

### DIFF
--- a/lib/network/modules/Canvas.js
+++ b/lib/network/modules/Canvas.js
@@ -120,11 +120,14 @@ class Canvas {
    * @private
    */
   _setCameraState() {
-    if (this.cameraState.scale !== undefined &&
+    if (
+      this.cameraState.scale !== undefined &&
       this.frame.canvas.clientWidth !== 0 &&
       this.frame.canvas.clientHeight !== 0 &&
       this.pixelRatio !== 0 &&
-      this.cameraState.previousWidth > 0) {
+      this.cameraState.previousWidth > 0 &&
+      this.cameraState.previousHeight > 0
+    ) {
 
       let widthRatio = (this.frame.canvas.width / this.pixelRatio) / this.cameraState.previousWidth;
       let heightRatio = (this.frame.canvas.height / this.pixelRatio) / this.cameraState.previousHeight;


### PR DESCRIPTION
There was already a check for zero width and this adds the same check for height. The problem is that with zeroes this results in values such as infinity being computed and eventually leads to various things turning into NaN as subsequent calculations fail.

Closes #340.