### PR TITLE
fix(nodes): update labels on constraint change

### DIFF
--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -188,13 +188,15 @@ class NodesHandler {
         }
       }
 
-      // update the font in all nodes
-      if (options.font !== undefined) {
-        for (let nodeId in this.body.nodes) {
-          if (this.body.nodes.hasOwnProperty(nodeId)) {
-            this.body.nodes[nodeId].updateLabelModule();
-            this.body.nodes[nodeId].needsRefresh();
-          }
+      // Update the labels of nodes if any relevant options changed.
+      if (
+        typeof options.font !== "undefined" ||
+        typeof options.widthConstraint !== "undefined" ||
+        typeof options.heightConstraint !== "undefined"
+      ) {
+        for (let nodeId of Object.keys(this.body.nodes)) {
+          this.body.nodes[nodeId].updateLabelModule();
+          this.body.nodes[nodeId].needsRefresh();
         }
       }
 


### PR DESCRIPTION
The label was updated only when the font or the label text itself changed but constraints affect it too so this triggers the update when they're changed.

Fixes #337.