### PR TITLE
Draft for Node Label Position

### DIFF
--- a/examples/network/labels/labelAlignment.html
+++ b/examples/network/labels/labelAlignment.html
@@ -20,10 +20,9 @@
 
 <body>
 
-<p>Labels of edges can be aligned to edges in various ways.</p>
-<p>Text-alignment within node labels can be 'left' or 'center', other font alignments not implemented.</p>
-<p>Label alignment (placement of label &quot;box&quot;) for nodes (top, bottom, left, right, inside) is
-planned but not in vis yet.</p>
+<p>Labels of edges can be aligned to edges either: <b>horizontal</b>, middle, top, or bottom.</p>
+<p>Text-alignment within node labels can be aligned: <b>center</b>, left, or right.</p>
+<p>For dot-like nodes, labels can be positioned at: <b>bottom</b>, inside, top, left, or right.</p>
 <p>The click event is captured and displayed to illustrate how the clicking on labels works.
 You can drag the nodes over each other to see how this influences the click event values.
 </p>
@@ -34,20 +33,28 @@ You can drag the nodes over each other to see how this influences the click even
 <script type="text/javascript">
   // create an array with nodes
   var nodes = [
-    {id: 1, label: 'Node 1'},
-    {id: 2, label: 'Node 2'},
-    {id: 3, label: 'Node 3:\nLeft-Aligned', font: {'face': 'Monospace', align: 'left'}},
-    {id: 4, label: 'Node 4'},
-    {id: 5, label: 'Node 5\nLeft-Aligned box', shape: 'box',
-     font: {'face': 'Monospace', align: 'left'}}
+    {id: 1, label: 'Node 1:\nCenter-Aligned\n(default)'},
+    {id: 2, label: 'Node 2:\nLeft-Aligned', font: {align: 'left'}},
+    {id: 3, label: 'Node 3:\nLeft-Aligned Box\n', shape: 'box', font: {align: 'left'}},
+    {id: 4, label: 'Node 4:\nRight-Aligned Box\n', shape: 'box', font: {align: 'right'}},
+    {id: 5, label: 'Node 5:\nBottom Label\n(default)', shape: 'dot', size: 40, color:"blue"},
+    {id: 6, label: 'Node 6:\nTop Label', shape: 'dot', labelPosition:'top', size: 40, color:"blue"},
+    {id: 7, label: 'Node 7:\nInside Label', shape: 'dot', labelPosition:'inside', size: 10, color:"yellow"},
+    {id: 8, label: 'Node 8:\nLeft Label', shape: 'dot', labelPosition:'left', size: 10, color:"green"},
+    {id: 9, label: 'Node 9:\nRight Label', shape: 'dot', labelPosition:'right', size:40, color:"green"},
   ];
 
   // create an array with edges
   var edges = [
     {from: 1, to: 2, label: 'middle',     font: {align: 'middle'}},
-    {from: 1, to: 3, label: 'top',        font: {align: 'top'}},
-    {from: 2, to: 4, label: 'horizontal', font: {align: 'horizontal'}},
-    {from: 2, to: 5, label: 'bottom',     font: {align: 'bottom'}}
+    {from: 2, to: 3, label: 'top',        font: {align: 'top'}},
+    {from: 3, to: 4, label: 'horizontal', font: {align: 'horizontal'}},
+    {from: 4, to: 1, label: 'bottom',     font: {align: 'bottom'}},
+    {from: 1, to: 5},
+    {from: 5, to: 6},
+    {from: 5, to: 7},
+    {from: 5, to: 8},
+    {from: 8, to: 9},
   ];
 
   // create a network

--- a/lib/network/modules/components/Node.js
+++ b/lib/network/modules/components/Node.js
@@ -511,7 +511,7 @@ class Node {
 
 
   /**
-   * check if this node is selecte
+   * check if this node is selected
    * @return {boolean} selected   True if node is selected, else false
    */
   isSelected() {

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-prototype-builtins */
 import * as util from 'vis-util';
 import ComponentUtil from './ComponentUtil';
 import LabelSplitter from './LabelSplitter';
@@ -21,12 +22,13 @@ class Label {
    * @param {boolean} [edgelabel=false]
    */
   constructor(body, options, edgelabel = false) {
-    this.body = body;
+    this.body = body; // suggestion: pass in just scale since we only use this.body.view.scale
     this.pointToSelf = false;
     this.baseSize = undefined;
     this.fontOptions = {};      // instance variable containing the *instance-local* font options
     this.setOptions(options);
     this.size = {top: 0, left: 0, width: 0, height: 0, yLine: 0};
+    this.position = undefined;
     this.isEdgeLabel = edgelabel;
   }
 
@@ -44,6 +46,12 @@ class Label {
     } else {
       // Bad label! Change the option value to prevent bad stuff happening
       options.label = undefined
+    }
+
+    if(options.labelPosition !== undefined && options.labelPosition !== null) {
+      if(typeof options.labelPosition === 'string'){
+        this.position = options.labelPosition;
+      }
     }
 
     if (options.font !== undefined && options.font !== null) { // font options can be deleted at various levels
@@ -509,8 +517,7 @@ class Label {
    * @private
    */
   _setAlignment(ctx, x, y, baseline) {
-    // check for label alignment (for edges)
-    // TODO: make alignment for nodes
+    // check for edge label alignment
     if (this.isEdgeLabel && this.fontOptions.align !== 'horizontal' && this.pointToSelf === false) {
       x = 0;
       y = 0;
@@ -528,8 +535,39 @@ class Label {
         ctx.textBaseline = 'middle';
       }
     }
+    // check for node label alignment
     else {
       ctx.textBaseline = baseline;
+
+      // this.size = {top, left, width, height, yLine};
+      // what is yLine?
+      // how does it currently get y value to position the label below node?
+      // suggestion: alignment offsets to be based on center/origin of node rather bottom
+      // suggestion: would 'dimensions' be a better name than 'size'?
+
+      let nodeSize = 30;
+      let distance = 5;
+      
+      switch(this.position){
+        case 'inside':
+          y -= (this.size.height / 2) + nodeSize + distance; // shift up to middle of node
+          break;
+        case 'left':
+          this.fontOptions.align = 'right'; // set font alignment to right
+          y -= (this.size.height / 2) + nodeSize + distance; // shift up to middle of node
+          x -= (nodeSize + distance) * 2; // shift left
+          break;
+        case 'right':
+          this.fontOptions.align = 'left'; // set font alignment to left
+          y -= (this.size.height / 2) + nodeSize + distance; // shift up to middle of node
+          x += (nodeSize + distance) * 2; // shift right   
+          break;
+        case 'top':
+          y -= this.size.height + (nodeSize + distance) * 2; // shift up to above node
+          break;
+        default:
+          // default: bottom
+      }
     }
     return [x,y];
   }


### PR DESCRIPTION
For #365 

Works fine for default size nodes with constant values for x/y offsets. Need to include the node radius/size in the offset instead. 

I have a couple questions and thoughts/suggestions. 

Questions:
1) In the label.size, what is the yLine?
2) How does it currently get the y value/distance to position the label below a node?
3) How can I get the node width/height to use as offset for label alignment?

Thoughts/Suggestions:
* Based on the usage and contents of the object, 'dimensions' seems a more appropriate name than 'size' (worried about changing it in case it's used elsewhere)
* The whole network body is passed in for label creation, but it looks like only view.scale is used - why not just pass in the scale?
* Positioning label given center/origin of a node would probably make more sense than adjusting based on current position at bottom (related to question 2 above)