### PR TITLE
Node ID type ("String" -> "Number or String")

### DIFF
--- a/docs/network/nodes.html
+++ b/docs/network/nodes.html
@@ -737,7 +737,7 @@ network.setOptions(options);
         </tr>
         <tr>
             <td>id</td>
-            <td>String</td>
+            <td>Number or String</td>
             <td><code>undefined</code></td>
             <td>The id of the node. The id is mandatory for nodes and they have to be unique. This should obviously be set per node, not globally.</td>
         </tr>


### PR DESCRIPTION
Hi,

Node ID is described as "String", but...
... almost all demo/examples I could see had numeric IDs
... some functionalities only work on fields having numeric values (see DataSet.max(), for instance).

-> so this pull request aims at describing node ID as "Number or String".
How modest it might be, this is my first contribution on github, hope I didn't miss a step ;-)