### PR TITLE
fix(hierarchical-repulsion-solver): remove assignment to const

### DIFF
--- a/lib/network/modules/components/physics/HierarchicalRepulsionSolver.js
+++ b/lib/network/modules/components/physics/HierarchicalRepulsionSolver.js
@@ -67,9 +67,7 @@ class HierarchicalRepulsionSolver {
             repulsingForce = 0;
           }
           // normalize force with
-          if (distance === 0) {
-            distance = 0.01;
-          } else {
+          if (distance !== 0) {
             repulsingForce = repulsingForce / distance;
           }
           const fx = dx * repulsingForce;


### PR DESCRIPTION
I have no idea why it was assigned in the first place. The new value was not used for anything at all.

Closes #555.