### PR TITLE
Don't override Node options with Group options

### DIFF
--- a/lib/network/modules/components/Node.js
+++ b/lib/network/modules/components/Node.js
@@ -247,12 +247,10 @@ class Node {
       }
     }
 
-    // Skip merging of group font options into parent; these are required to be distinct for labels
-    // Also skip mergin of color IF it is already defined in the node itself. This is to avoid the color of the
-    // group overriding the color set at the node level
-    // TODO: It might not be a good idea either to merge the rest of the options, investigate this.
-    var skipProperties = ['font'];
-    if (newOptions !== undefined && newOptions.color !== undefined && newOptions.color != null) skipProperties.push('color');
+    // Skip any new option to avoid them being overridden by the group options.
+    const skipProperties = Object.getOwnPropertyNames(newOptions).filter(p => newOptions[p] != null);
+    // Always skip merging group font options into parent; these are required to be distinct for labels
+    skipProperties.push('font');
     util.selectiveNotDeepExtend(skipProperties, parentOptions, groupObj);
 
     // the color object needs to be completely defined.


### PR DESCRIPTION
Node options are being overridden by the values defined by the Group, which should be the case, since more specific options (node) should have priority over more generic ones (group).

This [was fixed for `color`](https://github.com/almende/vis/issues/3713), but there are still many useful options such as borderWidth, image, and shape that are being overridden.

With this PR we fix this by not merging from the group any new option that has been set for the node.

Fix #408
