### PR TITLE
Fix incorrect backing up of edge smooth options

### DIFF
--- a/lib/network/modules/LayoutEngine.js
+++ b/lib/network/modules/LayoutEngine.js
@@ -505,7 +505,12 @@ class LayoutEngine {
 
           // TODO: this is options merging; see if the standard routines can be used here.
           this.optionsBackup.edges = {
-            smooth        : smooth
+            smooth: {
+              enabled       : smooth.enabled        === undefined ? true     : smooth.enabled,
+              type          : smooth.type           === undefined ? 'dynamic': smooth.type,
+              roundness     : smooth.roundness      === undefined ? 0.5      : smooth.roundness,
+              forceDirection: smooth.forceDirection === undefined ? false    : smooth.forceDirection
+            }
           };
 
 

--- a/lib/network/modules/LayoutEngine.js
+++ b/lib/network/modules/LayoutEngine.js
@@ -505,10 +505,7 @@ class LayoutEngine {
 
           // TODO: this is options merging; see if the standard routines can be used here.
           this.optionsBackup.edges = {
-            smooth        : smooth.enabled        === undefined ? true     : smooth.enabled,
-            type          : smooth.type           === undefined ? 'dynamic': smooth.type,
-            roundness     : smooth.roundness      === undefined ? 0.5      : smooth.roundness,
-            forceDirection: smooth.forceDirection === undefined ? false    : smooth.forceDirection
+            smooth        : smooth
           };
 
 


### PR DESCRIPTION
Hi,

This is a bug fix for when switching to hierarchical layout and backing up previous edge smooth options. The options were being backed up to `options.edges` instead of `options.edges.smooth`

I don't think this requires an example.
