### PR TITLE
fix(types): add missing index file

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./index-legacy-bundle";


### PR DESCRIPTION
The entry d.ts file for default export was missing, this creates it and therefore fixes errors when used in TS projects.

Closes #682.
Closes #649.