### PR TITLE
Update ManipulationSystem.js

### DIFF
--- a/lib/network/modules/ManipulationSystem.js
+++ b/lib/network/modules/ManipulationSystem.js
@@ -1017,6 +1017,9 @@ class ManipulationSystem {
       this.lastTouch = this.body.functions.getPointer(event.center);
       this.lastTouch.translation = util.extend({},this.body.view.translation); // copy the object
 
+      this.interactionHandler.drag.pointer = this.lastTouch; // Drag pointer is not updated when adding edges
+      this.interactionHandler.drag.translation = this.lastTouch.translation;
+      
       let pointer = this.lastTouch;
       let node = this.selectionHandler.getNodeAt(pointer);
 


### PR DESCRIPTION
Fixes #655
Fixes #603

[BUG FIX]
Pan when adding edges was broken

Cause:
Drag pointer was not updated before drag (pan) when in edges mode.

See #603 for detailed description of bug and example