### PR TITLE
Fix two fingers drag bug (#709)

### DIFF
--- a/lib/network/modules/InteractionHandler.js
+++ b/lib/network/modules/InteractionHandler.js
@@ -287,6 +287,12 @@ class InteractionHandler {
    * @private
    */
   onDragStart(event) {
+    // if already dragging, do not start
+    // this can happen on touch screens with multiple fingers
+    if(this.drag.dragging){
+      return;
+    }
+
     //in case the touch event was triggered on an external div, do the initial touch now.
     if (this.drag.pointer === undefined) {
       this.onTouch(event);


### PR DESCRIPTION
Fixes https://github.com/visjs/vis-network/issues/709

This check ensures that the drag start event is not fired if already dragging. Fixes issue when more than 1 finger may be used on the screen to fire a drag. 

Tests ran fine, and basic examples testing also observed no new bugs.