### PR TITLE
chore: automerge non-major dependencies versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,11 @@
 {
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "updateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
I've been running after merging patches and minor dependencies from npm.
Thanks to renovate, this is does open PRs automatically but it does seem to spam versions and PRs which kinda sucks sometimes because they should be simply automatically merged in...

This PR will automatically merge them with no human interventions.