### PR TITLE
perf: use more named imports and rewrite some CJS to ESM

### DIFF
--- a/examples/network/data/importingFromGephi.html
+++ b/examples/network/data/importingFromGephi.html
@@ -11,6 +11,11 @@
     type="text/javascript"
     src="../../../standalone/umd/vis-network.min.js"
   ></script>
+
+  <script
+    type="text/javascript"
+    src="https://unpkg.com/alea@1.0.0/alea.js"
+  ></script>
   <script type="text/javascript" src="../exampleUtil.js"></script>
 
   <style type="text/css">

--- a/examples/network/exampleUtil.js
+++ b/examples/network/exampleUtil.js
@@ -2,8 +2,7 @@
  * Created by Alex on 5/20/2015.
  *
  * @remarks
- * This depends on Alea from Vis Util and therefore has to be loaded AFTER Vis
- * Util or standalone Vis Network has already been loaded.
+ * This depends on Alea from https://unpkg.com/alea@1.0.0/alea.js.
  */
 
 function loadJSON(path, success, error) {
@@ -73,7 +72,7 @@ function getScaleFreeNetwork(nodeCount) {
   return {nodes:nodes, edges:edges};
 }
 
-var seededRandom = vis.util.Alea('SEED')
+var seededRandom = Alea('SEED')
 
 function getScaleFreeNetworkSeeded(nodeCount, seed) {
   if (seed) {

--- a/examples/network/layout/hierarchicalLayout.html
+++ b/examples/network/layout/hierarchicalLayout.html
@@ -19,6 +19,11 @@
       type="text/javascript"
       src="../../../standalone/umd/vis-network.min.js"
     ></script>
+
+    <script
+      type="text/javascript"
+      src="https://unpkg.com/alea@1.0.0/alea.js"
+    ></script>
     <script type="text/javascript" src="../exampleUtil.js"></script>
 
     <script type="text/javascript">

--- a/examples/network/other/animationShowcase.html
+++ b/examples/network/other/animationShowcase.html
@@ -38,6 +38,11 @@
     type="text/javascript"
     src="../../../standalone/umd/vis-network.min.js"
   ></script>
+
+  <script
+    type="text/javascript"
+    src="https://unpkg.com/alea@1.0.0/alea.js"
+  ></script>
   <script type="text/javascript" src="../exampleUtil.js"></script>
 
   <script type="text/javascript">

--- a/examples/network/other/configuration.html
+++ b/examples/network/other/configuration.html
@@ -30,6 +30,11 @@
     type="text/javascript"
     src="../../../standalone/umd/vis-network.min.js"
   ></script>
+
+  <script
+    type="text/javascript"
+    src="https://unpkg.com/alea@1.0.0/alea.js"
+  ></script>
   <script type="text/javascript" src="../exampleUtil.js"></script>
 
   <script type="text/javascript">

--- a/examples/network/other/manipulation.html
+++ b/examples/network/other/manipulation.html
@@ -58,6 +58,11 @@
     type="text/javascript"
     src="../../../standalone/umd/vis-network.min.js"
   ></script>
+
+  <script
+    type="text/javascript"
+    src="https://unpkg.com/alea@1.0.0/alea.js"
+  ></script>
   <script type="text/javascript" src="../exampleUtil.js"></script>
 
   <script type="text/javascript">

--- a/examples/network/other/manipulationEditEdgeNoDrag.html
+++ b/examples/network/other/manipulationEditEdgeNoDrag.html
@@ -73,6 +73,11 @@
     type="text/javascript"
     src="../../../standalone/umd/vis-network.min.js"
   ></script>
+
+  <script
+    type="text/javascript"
+    src="https://unpkg.com/alea@1.0.0/alea.js"
+  ></script>
   <script type="text/javascript" src="../exampleUtil.js"></script>
 
   <script type="text/javascript">

--- a/examples/network/other/navigation.html
+++ b/examples/network/other/navigation.html
@@ -31,6 +31,11 @@
     type="text/javascript"
     src="../../../standalone/umd/vis-network.min.js"
   ></script>
+
+  <script
+    type="text/javascript"
+    src="https://unpkg.com/alea@1.0.0/alea.js"
+  ></script>
   <script type="text/javascript" src="../exampleUtil.js"></script>
 
   <script type="text/javascript">

--- a/examples/network/other/performance.html
+++ b/examples/network/other/performance.html
@@ -26,6 +26,11 @@
     type="text/javascript"
     src="../../../standalone/umd/vis-network.min.js"
   ></script>
+
+  <script
+    type="text/javascript"
+    src="https://unpkg.com/alea@1.0.0/alea.js"
+  ></script>
   <script type="text/javascript" src="../exampleUtil.js"></script>
 
   <script type="text/javascript">

--- a/examples/network/other/saveAndLoad.html
+++ b/examples/network/other/saveAndLoad.html
@@ -36,6 +36,11 @@
           type="text/javascript"
           src="../../../standalone/umd/vis-network.min.js"
         ></script>
+
+        <script
+          type="text/javascript"
+          src="https://unpkg.com/alea@1.0.0/alea.js"
+        ></script>
         <script type="text/javascript" src="../exampleUtil.js"></script>
     </head>
 

--- a/examples/network/physics/physicsConfiguration.html
+++ b/examples/network/physics/physicsConfiguration.html
@@ -26,6 +26,11 @@
     type="text/javascript"
     src="../../../standalone/umd/vis-network.min.js"
   ></script>
+
+  <script
+    type="text/javascript"
+    src="https://unpkg.com/alea@1.0.0/alea.js"
+  ></script>
   <script type="text/javascript" src="../exampleUtil.js"></script>
 
   <script type="text/javascript">

--- a/lib/DOMutil.js
+++ b/lib/DOMutil.js
@@ -5,7 +5,7 @@
  * @param {Object} JSONcontainer
  * @private
  */
-exports.prepareElements = function(JSONcontainer) {
+export function prepareElements (JSONcontainer) {
   // cleanup the redundant svgElements;
   for (var elementType in JSONcontainer) {
     if (JSONcontainer.hasOwnProperty(elementType)) {
@@ -13,7 +13,7 @@ exports.prepareElements = function(JSONcontainer) {
       JSONcontainer[elementType].used = [];
     }
   }
-};
+}
 
 /**
  * this cleans up all the unused SVG elements. By asking for the parentNode, we only need to supply the JSON container from
@@ -22,7 +22,7 @@ exports.prepareElements = function(JSONcontainer) {
  * @param {Object} JSONcontainer
  * @private
  */
-exports.cleanupElements = function(JSONcontainer) {
+export function cleanupElements (JSONcontainer) {
   // cleanup the redundant svgElements;
   for (var elementType in JSONcontainer) {
     if (JSONcontainer.hasOwnProperty(elementType)) {
@@ -34,17 +34,17 @@ exports.cleanupElements = function(JSONcontainer) {
       }
     }
   }
-};
+}
 
 /**
  * Ensures that all elements are removed first up so they can be recreated cleanly
  * @param {Object} JSONcontainer
  */
-exports.resetElements = function(JSONcontainer) {
-  exports.prepareElements(JSONcontainer);
-  exports.cleanupElements(JSONcontainer);
-  exports.prepareElements(JSONcontainer);
-};
+export function resetElements (JSONcontainer) {
+  prepareElements(JSONcontainer);
+  cleanupElements(JSONcontainer);
+  prepareElements(JSONcontainer);
+}
 
 /**
  * Allocate or generate an SVG element if needed. Store a reference to it in the JSON container and draw it in the svgContainer
@@ -56,7 +56,7 @@ exports.resetElements = function(JSONcontainer) {
  * @returns {Element}
  * @private
  */
-exports.getSVGElement = function (elementType, JSONcontainer, svgContainer) {
+export function getSVGElement (elementType, JSONcontainer, svgContainer) {
   var element;
   // allocate SVG element, if it doesnt yet exist, create one.
   if (JSONcontainer.hasOwnProperty(elementType)) { // this element has been created before
@@ -79,7 +79,7 @@ exports.getSVGElement = function (elementType, JSONcontainer, svgContainer) {
   }
   JSONcontainer[elementType].used.push(element);
   return element;
-};
+}
 
 
 /**
@@ -92,7 +92,7 @@ exports.getSVGElement = function (elementType, JSONcontainer, svgContainer) {
  * @param {Element} insertBefore
  * @returns {*}
  */
-exports.getDOMElement = function (elementType, JSONcontainer, DOMContainer, insertBefore) {
+export function getDOMElement (elementType, JSONcontainer, DOMContainer, insertBefore) {
   var element;
   // allocate DOM element, if it doesnt yet exist, create one.
   if (JSONcontainer.hasOwnProperty(elementType)) { // this element has been created before
@@ -125,7 +125,7 @@ exports.getDOMElement = function (elementType, JSONcontainer, DOMContainer, inse
   }
   JSONcontainer[elementType].used.push(element);
   return element;
-};
+}
 
 
 
@@ -143,16 +143,16 @@ exports.getDOMElement = function (elementType, JSONcontainer, DOMContainer, inse
  * @param {Object} labelObj
  * @returns {vis.PointItem}
  */
-exports.drawPoint = function(x, y, groupTemplate, JSONcontainer, svgContainer, labelObj) {
+export function drawPoint (x, y, groupTemplate, JSONcontainer, svgContainer, labelObj) {
   var point;
   if (groupTemplate.style == 'circle') {
-    point = exports.getSVGElement('circle', JSONcontainer, svgContainer);
+    point = getSVGElement('circle', JSONcontainer, svgContainer);
     point.setAttributeNS(null, "cx", x);
     point.setAttributeNS(null, "cy", y);
     point.setAttributeNS(null, "r", 0.5 * groupTemplate.size);
   }
   else {
-    point = exports.getSVGElement('rect', JSONcontainer, svgContainer);
+    point = getSVGElement('rect', JSONcontainer, svgContainer);
     point.setAttributeNS(null, "x", x - 0.5 * groupTemplate.size);
     point.setAttributeNS(null, "y", y - 0.5 * groupTemplate.size);
     point.setAttributeNS(null, "width", groupTemplate.size);
@@ -167,7 +167,7 @@ exports.drawPoint = function(x, y, groupTemplate, JSONcontainer, svgContainer, l
 
 
   if (labelObj) {
-    var label = exports.getSVGElement('text', JSONcontainer, svgContainer);
+    const label = getSVGElement('text', JSONcontainer, svgContainer);
     if (labelObj.xOffset) {
       x = x + labelObj.xOffset;
     }
@@ -187,7 +187,7 @@ exports.drawPoint = function(x, y, groupTemplate, JSONcontainer, svgContainer, l
   }
 
   return point;
-};
+}
 
 /**
  * draw a bar SVG element centered on the X coordinate
@@ -201,13 +201,13 @@ exports.drawPoint = function(x, y, groupTemplate, JSONcontainer, svgContainer, l
  * @param {Object} svgContainer
  * @param {string} style
  */
-exports.drawBar = function (x, y, width, height, className, JSONcontainer, svgContainer, style) {
+export function drawBar (x, y, width, height, className, JSONcontainer, svgContainer, style) {
   if (height != 0) {
     if (height < 0) {
       height *= -1;
       y -= height;
     }
-    var rect = exports.getSVGElement('rect',JSONcontainer, svgContainer);
+    const rect = getSVGElement('rect',JSONcontainer, svgContainer);
     rect.setAttributeNS(null, "x", x - 0.5 * width);
     rect.setAttributeNS(null, "y", y);
     rect.setAttributeNS(null, "width", width);
@@ -217,4 +217,4 @@ exports.drawBar = function (x, y, width, height, className, JSONcontainer, svgCo
       rect.setAttributeNS(null, "style", style);
     }
   }
-};
+}

--- a/lib/entry-standalone.ts
+++ b/lib/entry-standalone.ts
@@ -1,9 +1,5 @@
 export * from "./entry-esnext";
 
-// vis-util
-import * as util from "vis-util/esnext";
-export { util };
-
 // vis-data
 import * as data from "vis-data/esnext";
 export { data };

--- a/lib/hammerUtil.js
+++ b/lib/hammerUtil.js
@@ -3,7 +3,7 @@
  * @param {Hammer} hammer       A hammer instance
  * @param {function} callback   Callback, called as callback(event)
  */
-exports.onTouch = function (hammer, callback) {
+export function onTouch (hammer, callback) {
   callback.inputHandler = function (event) {
     if (event.isFirst) {
       callback(event);
@@ -11,7 +11,7 @@ exports.onTouch = function (hammer, callback) {
   };
 
   hammer.on('hammer.input', callback.inputHandler);
-};
+}
 
 /**
  * Register a release event, taking place after a gesture
@@ -19,7 +19,7 @@ exports.onTouch = function (hammer, callback) {
  * @param {function} callback   Callback, called as callback(event)
  * @returns {*}
  */
-exports.onRelease = function (hammer, callback) {
+export function onRelease (hammer, callback) {
   callback.inputHandler = function (event) {
     if (event.isFinal) {
       callback(event);
@@ -27,7 +27,7 @@ exports.onRelease = function (hammer, callback) {
   };
 
   return hammer.on('hammer.input', callback.inputHandler);
-};
+}
 
 
 /**
@@ -35,16 +35,16 @@ exports.onRelease = function (hammer, callback) {
  * @param {Hammer} hammer       A hammer instance
  * @param {function} callback   Callback, called as callback(event)
  */
-exports.offTouch = function (hammer, callback) {
+export function offTouch (hammer, callback) {
   hammer.off('hammer.input', callback.inputHandler);
-};
+}
 
 /**
  * Unregister a release event, taking place before a gesture
  * @param {Hammer} hammer       A hammer instance
  * @param {function} callback   Callback, called as callback(event)
  */
-exports.offRelease = exports.offTouch;
+export const offRelease = offTouch;
 
 /**
  * Hack the PinchRecognizer such that it doesn't prevent default behavior
@@ -55,7 +55,7 @@ exports.offRelease = exports.offTouch;
  * @param {Hammer.Pinch} pinchRecognizer
  * @return {Hammer.Pinch} returns the pinchRecognizer
  */
-exports.disablePreventDefaultVertically = function (pinchRecognizer) {
+export function disablePreventDefaultVertically (pinchRecognizer) {
   var TOUCH_ACTION_PAN_Y = 'pan-y';
 
   pinchRecognizer.getTouchAction = function() {
@@ -64,4 +64,4 @@ exports.disablePreventDefaultVertically = function (pinchRecognizer) {
   };
 
   return pinchRecognizer;
-};
+}

--- a/lib/network/Network.js
+++ b/lib/network/Network.js
@@ -2,9 +2,13 @@
 import './shapes';
 
 import Emitter from 'component-emitter';
-import * as util from 'vis-util/esnext';
+import {
+  deepExtend,
+  recursiveDOMDelete,
+  selectiveDeepExtend,
+} from 'vis-util/esnext';
 import dotparser from './dotparser';
-import * as gephiParser from './gephiParser';
+import { parseGephi } from './gephiParser';
 import Activator from '../shared/Activator';
 import * as locales from './locales';
 import { normalizeLanguageCode } from './locale-utils';
@@ -51,7 +55,7 @@ export function Network(container, data, options) {
     locales: locales,
     clickToUse: false
   };
-  util.extend(this.options, this.defaultOptions);
+  Object.assign(this.options, this.defaultOptions);
 
   /**
    * Containers for nodes and edges.
@@ -166,7 +170,7 @@ Network.prototype.setOptions = function (options) {
 
     // copy the global fields over
     let fields = ['locale','locales','clickToUse'];
-    util.selectiveDeepExtend(fields,this.options, options);
+    selectiveDeepExtend(fields,this.options, options);
 
     // normalize the locale or use English
     if (options.locale !== undefined) {
@@ -211,20 +215,20 @@ Network.prototype.setOptions = function (options) {
     // if the configuration system is enabled, copy all options and put them into the config system
     if (this.configurator && this.configurator.options.enabled === true) {
       let networkOptions = {nodes:{},edges:{},layout:{},interaction:{},manipulation:{},physics:{},global:{}};
-      util.deepExtend(networkOptions.nodes,        this.nodesHandler.options);
-      util.deepExtend(networkOptions.edges,        this.edgesHandler.options);
-      util.deepExtend(networkOptions.layout,       this.layoutEngine.options);
+      deepExtend(networkOptions.nodes,        this.nodesHandler.options);
+      deepExtend(networkOptions.edges,        this.edgesHandler.options);
+      deepExtend(networkOptions.layout,       this.layoutEngine.options);
       // load the selectionHandler and render default options in to the interaction group
-      util.deepExtend(networkOptions.interaction,  this.selectionHandler.options);
-      util.deepExtend(networkOptions.interaction,  this.renderer.options);
+      deepExtend(networkOptions.interaction,  this.selectionHandler.options);
+      deepExtend(networkOptions.interaction,  this.renderer.options);
 
-      util.deepExtend(networkOptions.interaction,  this.interactionHandler.options);
-      util.deepExtend(networkOptions.manipulation, this.manipulation.options);
-      util.deepExtend(networkOptions.physics,      this.physics.options);
+      deepExtend(networkOptions.interaction,  this.interactionHandler.options);
+      deepExtend(networkOptions.manipulation, this.manipulation.options);
+      deepExtend(networkOptions.physics,      this.physics.options);
 
       // load globals into the global object
-      util.deepExtend(networkOptions.global,       this.canvas.options);
-      util.deepExtend(networkOptions.global,       this.options);
+      deepExtend(networkOptions.global,       this.canvas.options);
+      deepExtend(networkOptions.global,       this.options);
 
       this.configurator.setModuleOptions(networkOptions);
     }
@@ -366,7 +370,7 @@ Network.prototype.setData = function (data) {
   else if (data && data.gephi) {
     // parse DOT file
     console.log('The gephi property has been deprecated. Please use the static convertGephi method to convert gephi into vis.network format and use the normal data format with nodes and edges. This converter is used like this: var data = vis.network.convertGephi(gephiJson);');
-    var gephiData = gephiParser.parseGephi(data.gephi);
+    var gephiData = parseGephi(data.gephi);
     this.setData(gephiData);
     return;
   }
@@ -425,7 +429,7 @@ Network.prototype.destroy = function () {
   }
 
   // remove the container and everything inside it recursively
-  util.recursiveDOMDelete(this.body.container);
+  recursiveDOMDelete(this.body.container);
 };
 
 

--- a/lib/network/Network.js
+++ b/lib/network/Network.js
@@ -7,7 +7,7 @@ import {
   recursiveDOMDelete,
   selectiveDeepExtend,
 } from 'vis-util/esnext';
-import dotparser from './dotparser';
+import { DOTToGraph } from './dotparser';
 import { parseGephi } from './gephiParser';
 import Activator from '../shared/Activator';
 import * as locales from './locales';
@@ -363,7 +363,7 @@ Network.prototype.setData = function (data) {
   if (data && data.dot) {
     console.log('The dot property has been deprecated. Please use the static convertDot method to convert DOT into vis.network format and use the normal data format with nodes and edges. This converter is used like this: var data = vis.network.convertDot(dotString);');
     // parse DOT file
-    var dotData = dotparser.DOTToGraph(data.dot);
+    var dotData = DOTToGraph(data.dot);
     this.setData(dotData);
     return;
   }

--- a/lib/network/NetworkUtil.js
+++ b/lib/network/NetworkUtil.js
@@ -1,4 +1,4 @@
-import * as util from 'vis-util/esnext';
+import { deepExtend } from 'vis-util/esnext';
 
 /**
  * Utility Class
@@ -99,13 +99,13 @@ class NetworkUtil {
   static cloneOptions(item, type) {
     let clonedOptions = {};
     if (type === undefined || type === 'node') {
-      util.deepExtend(clonedOptions, item.options, true);
+      deepExtend(clonedOptions, item.options, true);
       clonedOptions.x = item.x;
       clonedOptions.y = item.y;
       clonedOptions.amountOfConnections = item.edges.length;
     }
     else {
-      util.deepExtend(clonedOptions, item.options, true);
+      deepExtend(clonedOptions, item.options, true);
     }
     return clonedOptions;
   }

--- a/lib/network/dotparser.js
+++ b/lib/network/dotparser.js
@@ -34,7 +34,7 @@
  * - Note that text explicitly says 'labels'; the dot parser currently handles escape
  *   sequences in **all** strings.
  */
-function parseDOT (data) {
+export function parseDOT (data) {
   dot = data;
   return parseGraph();
 }
@@ -1399,7 +1399,7 @@ function convertAttr (attr, mapping) {
  * @param {string} data         Text containing a graph in DOT-notation
  * @return {Object} graphData
  */
-function DOTToGraph (data) {
+export function DOTToGraph (data) {
   // parse the DOT file
   var dotData = parseDOT(data);
   var graphData = {
@@ -1496,7 +1496,3 @@ function DOTToGraph (data) {
 
   return graphData;
 }
-
-// exports
-exports.parseDOT   = parseDOT;
-exports.DOTToGraph = DOTToGraph;

--- a/lib/network/modules/Canvas.js
+++ b/lib/network/modules/Canvas.js
@@ -1,7 +1,11 @@
 import Hammer from '../../module/hammer';
 import hammerUtil from '../../hammerUtil';
 
-import * as util from 'vis-util/esnext';
+import {
+  addEventListener,
+  removeEventListener,
+  selectiveDeepExtend,
+} from 'vis-util/esnext';
 
 /**
  * Create the main frame for the Network.
@@ -28,7 +32,7 @@ class Canvas {
       height: '100%',
       width: '100%'
     };
-    util.extend(this.options, this.defaultOptions);
+    Object.assign(this.options, this.defaultOptions);
 
     this.bindEventListeners();
   }
@@ -60,7 +64,7 @@ class Canvas {
   setOptions(options) {
     if (options !== undefined) {
       let fields = ['width','height','autoResize'];
-      util.selectiveDeepExtend(fields,this.options, options);
+      selectiveDeepExtend(fields,this.options, options);
     }
 
     if (this.options.autoResize === true) {
@@ -73,7 +77,7 @@ class Canvas {
         }
       }, 1000);
       this.resizeFunction = this._onResize.bind(this);
-      util.addEventListener(window,'resize',this.resizeFunction);
+      addEventListener(window,'resize',this.resizeFunction);
     }
   }
 
@@ -85,7 +89,7 @@ class Canvas {
     if (this.resizeTimer !== undefined) {
       clearInterval(this.resizeTimer);
     }
-    util.removeEventListener(window,'resize',this.resizeFunction);
+    removeEventListener(window,'resize',this.resizeFunction);
     this.resizeFunction = undefined;
   }
 

--- a/lib/network/modules/Canvas.js
+++ b/lib/network/modules/Canvas.js
@@ -1,5 +1,5 @@
 import Hammer from '../../module/hammer';
-import hammerUtil from '../../hammerUtil';
+import { onRelease, onTouch } from '../../hammerUtil';
 
 import {
   addEventListener,
@@ -246,7 +246,7 @@ class Canvas {
     // enable to get better response, todo: test on mobile.
     this.hammer.get('pan').set({threshold:5, direction: Hammer.DIRECTION_ALL});
 
-    hammerUtil.onTouch(this.hammer, (event) => {this.body.eventListeners.onTouch(event)});
+    onTouch(this.hammer, (event) => {this.body.eventListeners.onTouch(event)});
     this.hammer.on('tap',       (event) => {this.body.eventListeners.onTap(event)});
     this.hammer.on('doubletap', (event) => {this.body.eventListeners.onDoubleTap(event)});
     this.hammer.on('press',     (event) => {this.body.eventListeners.onHold(event)});
@@ -262,7 +262,7 @@ class Canvas {
     this.frame.canvas.addEventListener('contextmenu', (event) => {this.body.eventListeners.onContext(event)});
 
     this.hammerFrame = new Hammer(this.frame);
-    hammerUtil.onRelease(this.hammerFrame, (event) => {this.body.eventListeners.onRelease(event)});
+    onRelease(this.hammerFrame, (event) => {this.body.eventListeners.onRelease(event)});
   }
 
 

--- a/lib/network/modules/CanvasRenderer.js
+++ b/lib/network/modules/CanvasRenderer.js
@@ -1,3 +1,5 @@
+import { selectiveDeepExtend } from 'vis-util/esnext';
+
 /**
  * Initializes window.requestAnimationFrame() to a usable form.
  *
@@ -41,8 +43,6 @@ function _initRequestAnimationFrame() {
   }
 }
 
-import * as util from 'vis-util/esnext';
-
 /**
  * The canvas renderer
  */
@@ -71,7 +71,7 @@ class CanvasRenderer {
       hideEdgesOnZoom: false,
       hideNodesOnDrag: false,
     };
-    util.extend(this.options, this.defaultOptions);
+    Object.assign(this.options, this.defaultOptions);
 
     this._determineBrowserMethod();
     this.bindEventListeners();
@@ -133,7 +133,7 @@ class CanvasRenderer {
   setOptions(options) {
     if (options !== undefined) {
       let fields = ['hideEdgesOnDrag', 'hideEdgesOnZoom', 'hideNodesOnDrag'];
-      util.selectiveDeepExtend(fields,this.options, options);
+      selectiveDeepExtend(fields,this.options, options);
     }
   }
 

--- a/lib/network/modules/Clustering.js
+++ b/lib/network/modules/Clustering.js
@@ -90,7 +90,7 @@ member:
 
 
    =========================================================================== */
-import * as util from 'vis-util/esnext';
+import { deepExtend, forEach } from 'vis-util/esnext';
 import { v4 as randomUUID } from 'uuid';
 import NetworkUtil from'../NetworkUtil';
 import Cluster from'./components/nodes/Cluster';
@@ -111,7 +111,7 @@ class ClusterEngine {
 
     this.options = {};
     this.defaultOptions = {};
-    util.extend(this.options, this.defaultOptions);
+    Object.assign(this.options, this.defaultOptions);
 
     this.body.emitter.on('_resetData', () => {this.clusteredNodes = {}; this.clusteredEdges = {};})
   }
@@ -161,12 +161,12 @@ class ClusterEngine {
     let childEdgesObj = {};
 
     // collect the nodes that will be in the cluster
-    util.forEach(this.body.nodes, (node, nodeId) => {
+    forEach(this.body.nodes, (node, nodeId) => {
       if (node.options && options.joinCondition(node.options) === true) {
         childNodesObj[nodeId] = node;
 
         // collect the edges that will be in the cluster
-        util.forEach(node.edges, (edge) => {
+        forEach(node.edges, (edge) => {
           if (this.clusteredEdges[edge.id] === undefined) {
             childEdgesObj[edge.id] = edge;
           }
@@ -544,7 +544,7 @@ class ClusterEngine {
     // allow clusters of 1 if options allow
     if (Object.keys(childNodesObj).length == 1 && options.clusterNodeProperties.allowSingleNodeCluster != true) {return;}
 
-    let clusterNodeProperties = util.deepExtend({},options.clusterNodeProperties);
+    let clusterNodeProperties = deepExtend({},options.clusterNodeProperties);
 
     // construct the clusterNodeProperties
     if (options.processProperties !== undefined) {
@@ -757,7 +757,7 @@ class ClusterEngine {
     }
     else {
       // copy the position from the cluster
-      util.forEach(containedNodes, function(containedNode) {
+      forEach(containedNodes, function(containedNode) {
         // inherit position
         if (containedNode.options.fixed.x === false) {containedNode.x = clusterNode.x;}
         if (containedNode.options.fixed.y === false) {containedNode.y = clusterNode.y;}
@@ -1079,7 +1079,7 @@ class ClusterEngine {
     // copy the options of the edge we will replace
     let clonedOptions = NetworkUtil.cloneOptions(baseEdge, 'edge');
     // make sure the properties of clusterEdges are superimposed on it
-    util.deepExtend(clonedOptions, clusterEdgeProperties);
+    deepExtend(clonedOptions, clusterEdgeProperties);
 
     // set up the edge
     clonedOptions.from = fromId;
@@ -1088,7 +1088,7 @@ class ClusterEngine {
 
     // apply the edge specific options to it if specified
     if (extraOptions !== undefined) {
-      util.deepExtend(clonedOptions, extraOptions);
+      deepExtend(clonedOptions, extraOptions);
     }
 
     let newEdge = this.body.functions.createEdge(clonedOptions);
@@ -1199,7 +1199,7 @@ class ClusterEngine {
   _filter(arr, callback) {
     let ret = [];
 
-    util.forEach(arr, (item) => {
+    forEach(arr, (item) => {
       if (callback(item)) {
         ret.push(item);
       }
@@ -1229,7 +1229,7 @@ class ClusterEngine {
      * @param {Function} callback  function to call for each cluster node
      */
     let eachClusterNode = (callback) => {
-      util.forEach(this.body.nodes, (node) => {
+      forEach(this.body.nodes, (node) => {
         if (node.isCluster === true) {
           callback(node);
         }
@@ -1269,7 +1269,7 @@ class ClusterEngine {
     //
 
     // Add the deleted clustered edges to the list
-    util.forEach(this.clusteredEdges, (edgeId) => {
+    forEach(this.clusteredEdges, (edgeId) => {
       let edge = this.body.edges[edgeId];
       if (edge === undefined || !edge.endPointsValid()) {
         deletedEdgeIds[edgeId] = edgeId;
@@ -1280,7 +1280,7 @@ class ClusterEngine {
     // i.e. nodes 1-2 within cluster with an edge in between.
     // So the cluster nodes also need to be scanned for invalid edges
     eachClusterNode(function(clusterNode) {
-      util.forEach(clusterNode.containedEdges, (edge, edgeId) => {
+      forEach(clusterNode.containedEdges, (edge, edgeId) => {
         if (!edge.endPointsValid() && !deletedEdgeIds[edgeId]) {
           deletedEdgeIds[edgeId] = edgeId;
         }
@@ -1289,14 +1289,14 @@ class ClusterEngine {
 
     // Also scan for cluster edges which need to be removed in the active list.
     // Regular edges have been removed beforehand, so this only picks up the cluster edges.
-    util.forEach(this.body.edges, (edge, edgeId) => {
+    forEach(this.body.edges, (edge, edgeId) => {
       // Explicitly scan the contained edges for validity
       let isValid = true;
       let replacedIds = edge.clusteringEdgeReplacingIds;
       if (replacedIds !== undefined) {
         let numValid = 0;
 
-        util.forEach(replacedIds, (containedEdgeId) => {
+        forEach(replacedIds, (containedEdgeId) => {
           let containedEdge   = this.body.edges[containedEdgeId];
 
           if (containedEdge !== undefined && containedEdge.endPointsValid()) {
@@ -1314,10 +1314,10 @@ class ClusterEngine {
 
     // Remove edges from cluster nodes
     eachClusterNode((clusterNode) => {
-      util.forEach(deletedEdgeIds, (deletedEdgeId) => {
+      forEach(deletedEdgeIds, (deletedEdgeId) => {
         delete clusterNode.containedEdges[deletedEdgeId];
 
-        util.forEach(clusterNode.edges, (edge, m) => {
+        forEach(clusterNode.edges, (edge, m) => {
           if (edge.id === deletedEdgeId) {
             clusterNode.edges[m] = null;  // Don't want to directly delete here, because in the loop
             return;
@@ -1335,14 +1335,14 @@ class ClusterEngine {
 
 
     // Remove from cluster list
-    util.forEach(deletedEdgeIds, (edgeId) => {
+    forEach(deletedEdgeIds, (edgeId) => {
       delete this.clusteredEdges[edgeId];
     });
 
     // Remove cluster edges from active list (this.body.edges).
     // deletedEdgeIds still contains id of regular edges, but these should all
     // be gone when you reach here.
-    util.forEach(deletedEdgeIds, (edgeId) => {
+    forEach(deletedEdgeIds, (edgeId) => {
       delete this.body.edges[edgeId];
     });
 
@@ -1353,7 +1353,7 @@ class ClusterEngine {
 
     // Iterating over keys here, because edges may be removed in the loop
     let ids = Object.keys(this.body.edges);
-    util.forEach(ids, (edgeId) => {
+    forEach(ids, (edgeId) => {
       let edge = this.body.edges[edgeId];
 
       let shouldBeClustered = this._isClusteredNode(edge.fromId) || this._isClusteredNode(edge.toId);

--- a/lib/network/modules/EdgesHandler.js
+++ b/lib/network/modules/EdgesHandler.js
@@ -1,4 +1,4 @@
-import * as util from 'vis-util/esnext';
+import { deepExtend, forEach } from 'vis-util/esnext';
 import { DataSet, DataView } from 'vis-data/esnext';
 import Edge from './components/Edge';
 
@@ -127,7 +127,7 @@ class EdgesHandler {
       value: undefined
     };
 
-    util.deepExtend(this.options, this.defaultOptions);
+    deepExtend(this.options, this.defaultOptions);
 
     this.bindEventListeners();
   }
@@ -186,7 +186,7 @@ class EdgesHandler {
     this.body.emitter.on("refreshEdges", this.refresh.bind(this));
     this.body.emitter.on("refresh",      this.refresh.bind(this));
     this.body.emitter.on("destroy",      () => {
-      util.forEach(this.edgesListeners, (callback, event) => {
+      forEach(this.edgesListeners, (callback, event) => {
         if (this.body.data.edges)
           this.body.data.edges.off(event, callback);
       });
@@ -261,7 +261,7 @@ class EdgesHandler {
     // TODO: is this null or undefined or false?
     if (oldEdgesData) {
       // unsubscribe from old dataset
-      util.forEach(this.edgesListeners, (callback, event) => {oldEdgesData.off(event, callback);});
+      forEach(this.edgesListeners, (callback, event) => {oldEdgesData.off(event, callback);});
     }
 
     // remove drawn edges
@@ -270,7 +270,7 @@ class EdgesHandler {
     // TODO: is this null or undefined or false?
     if (this.body.data.edges) {
       // subscribe to new dataset
-      util.forEach(this.edgesListeners, (callback, event) =>  {this.body.data.edges.on(event, callback);});
+      forEach(this.edgesListeners, (callback, event) =>  {this.body.data.edges.on(event, callback);});
 
       // draw all new nodes
       var ids = this.body.data.edges.getIds();
@@ -361,7 +361,7 @@ class EdgesHandler {
     if (ids.length === 0) return;  // early out
 
     var edges = this.body.edges;
-    util.forEach(ids, (id) => {
+    forEach(ids, (id) => {
       var edge = edges[id];
       if (edge !== undefined) {
         edge.remove();
@@ -377,7 +377,7 @@ class EdgesHandler {
    * Refreshes Edge Handler
    */
   refresh() {
-    util.forEach(this.body.edges, (edge, edgeId) => {
+    forEach(this.body.edges, (edge, edgeId) => {
       const data = this.body.data.edges.get(edgeId);
       if (data !== undefined) {
         edge.setOptions(data);
@@ -457,7 +457,7 @@ class EdgesHandler {
     
     let edgesToDelete = [];
 
-    util.forEach(this.body.edges, (edge, id) => {
+    forEach(this.body.edges, (edge, id) => {
       let toNode = this.body.nodes[edge.toId];
       let fromNode = this.body.nodes[edge.fromId];
 

--- a/lib/network/modules/Groups.js
+++ b/lib/network/modules/Groups.js
@@ -1,5 +1,3 @@
-import * as util from 'vis-util/esnext';
-
 /**
  * This class can store groups and options specific for groups.
  */
@@ -43,7 +41,7 @@ class Groups {
     this.defaultOptions = {
       useDefaultGroups: true
     };
-    util.extend(this.options, this.defaultOptions);
+    Object.assign(this.options, this.defaultOptions);
   }
 
   /**

--- a/lib/network/modules/InteractionHandler.js
+++ b/lib/network/modules/InteractionHandler.js
@@ -1,4 +1,10 @@
-import * as util from 'vis-util/esnext';
+import {
+  getAbsoluteLeft,
+  getAbsoluteTop,
+  mergeOptions,
+  parseColor,
+  selectiveNotDeepExtend,
+} from 'vis-util/esnext';
 import NavigationHandler from './components/NavigationHandler';
 import Popup from './../../shared/Popup';
 
@@ -56,7 +62,7 @@ class InteractionHandler {
       zoomView: true,
       zoomSpeed: 1
     };
-    util.extend(this.options,this.defaultOptions);
+    Object.assign(this.options,this.defaultOptions);
 
     this.bindEventListeners()
   }
@@ -79,15 +85,15 @@ class InteractionHandler {
     if (options !== undefined) {
       // extend all but the values in fields
       let fields = ['hideEdgesOnDrag', 'hideEdgesOnZoom', 'hideNodesOnDrag','keyboard','multiselect','selectable','selectConnectedEdges'];
-      util.selectiveNotDeepExtend(fields, this.options, options);
+      selectiveNotDeepExtend(fields, this.options, options);
 
       // merge the keyboard options in.
-      util.mergeOptions(this.options, options, 'keyboard');
+      mergeOptions(this.options, options, 'keyboard');
 
       if (options.tooltip) {
-        util.extend(this.options.tooltip, options.tooltip);
+        Object.assign(this.options.tooltip, options.tooltip);
         if (options.tooltip.color) {
-          this.options.tooltip.color = util.parseColor(options.tooltip.color);
+          this.options.tooltip.color = parseColor(options.tooltip.color);
         }
       }
     }
@@ -104,8 +110,8 @@ class InteractionHandler {
    */
   getPointer(touch) {
     return {
-      x: touch.x - util.getAbsoluteLeft(this.canvas.frame.canvas),
-      y: touch.y - util.getAbsoluteTop(this.canvas.frame.canvas)
+      x: touch.x - getAbsoluteLeft(this.canvas.frame.canvas),
+      y: touch.y - getAbsoluteTop(this.canvas.frame.canvas)
     };
   }
 
@@ -303,7 +309,7 @@ class InteractionHandler {
 
     this.drag.dragging = true;
     this.drag.selection = [];
-    this.drag.translation = util.extend({},this.body.view.translation); // copy the object
+    this.drag.translation = Object.assign({},this.body.view.translation); // copy the object
     this.drag.nodeId = undefined;
 
     if (node !== undefined && this.options.dragNodes === true) {

--- a/lib/network/modules/LayoutEngine.js
+++ b/lib/network/modules/LayoutEngine.js
@@ -31,7 +31,12 @@
  */
 'use strict';
 import TimSort from 'timsort';
-import * as util from 'vis-util/esnext';
+import {
+  deepExtend,
+  forEach,
+  mergeOptions,
+  selectiveDeepExtend
+} from 'vis-util/esnext';
 import NetworkUtil from '../NetworkUtil';
 import { HorizontalStrategy, VerticalStrategy } from './components/DirectionStrategy.js';
 import {
@@ -357,7 +362,7 @@ class LayoutEngine {
         sortMethod: 'hubsize' // hubsize, directed
       }
     };
-    util.extend(this.options, this.defaultOptions);
+    Object.assign(this.options, this.defaultOptions);
     this.bindEventListeners();
   }
 
@@ -396,8 +401,8 @@ class LayoutEngine {
     if (options !== undefined) {
       let hierarchical = this.options.hierarchical;
       let prevHierarchicalState = hierarchical.enabled;
-      util.selectiveDeepExtend(["randomSeed", "improvedLayout", "clusterThreshold"],this.options, options);
-      util.mergeOptions(this.options, options, 'hierarchical');
+      selectiveDeepExtend(["randomSeed", "improvedLayout", "clusterThreshold"],this.options, options);
+      mergeOptions(this.options, options, 'hierarchical');
 
       if (options.randomSeed !== undefined) {
         this._resetRNG(options.randomSeed);
@@ -432,7 +437,7 @@ class LayoutEngine {
         if (prevHierarchicalState === true) {
           // refresh the overridden options for nodes and edges.
           this.body.emitter.emit('refresh');
-          return util.deepExtend(allOptions,this.optionsBackup);
+          return deepExtend(allOptions,this.optionsBackup);
         }
       }
     }
@@ -1405,7 +1410,7 @@ class LayoutEngine {
   _getActiveEdges(node) {
     let result = [];
 
-    util.forEach(node.edges, (edge) => { 
+    forEach(node.edges, (edge) => { 
       if (this.body.edgeIndices.indexOf(edge.id) !== -1) {
         result.push(edge);
       }
@@ -1425,7 +1430,7 @@ class LayoutEngine {
     let hubSizes = {};
     let nodeIds = this.body.nodeIndices;
 
-    util.forEach(nodeIds, (nodeId) => { 
+    forEach(nodeIds, (nodeId) => { 
       let node = this.body.nodes[nodeId];
       let hubSize = this._getActiveEdges(node).length;
       hubSizes[hubSize] = true;
@@ -1433,7 +1438,7 @@ class LayoutEngine {
 
     // Make an array of the size sorted descending
     let result = [];
-    util.forEach(hubSizes, (size) => { 
+    forEach(hubSizes, (size) => { 
       result.push(Number(size));
     });
 
@@ -1461,7 +1466,7 @@ class LayoutEngine {
       let hubSize = hubSizes[i];
       if (hubSize === 0) break;
 
-      util.forEach(this.body.nodeIndices, (nodeId) => { 
+      forEach(this.body.nodeIndices, (nodeId) => { 
         let node = this.body.nodes[nodeId];
 
         if (hubSize === this._getActiveEdges(node).length) {

--- a/lib/network/modules/ManipulationSystem.js
+++ b/lib/network/modules/ManipulationSystem.js
@@ -3,7 +3,7 @@ import './ManipulationSystem.css';
 import { deepExtend, recursiveDOMDelete } from 'vis-util/esnext';
 import { v4 as randomUUID } from 'uuid';
 import Hammer from '../../module/hammer';
-import hammerUtil from '../../hammerUtil';
+import { onTouch } from '../../hammerUtil';
 
 /**
  * Clears the toolbar div element of children
@@ -857,7 +857,7 @@ class ManipulationSystem {
    */
   _bindHammerToDiv(domElement, boundFunction) {
     let hammer = new Hammer(domElement, {});
-    hammerUtil.onTouch(hammer, boundFunction);
+    onTouch(hammer, boundFunction);
     this.manipulationHammers.push(hammer);
   }
 

--- a/lib/network/modules/ManipulationSystem.js
+++ b/lib/network/modules/ManipulationSystem.js
@@ -1,6 +1,6 @@
 import './ManipulationSystem.css';
 
-import * as util from 'vis-util/esnext';
+import { deepExtend, recursiveDOMDelete } from 'vis-util/esnext';
 import { v4 as randomUUID } from 'uuid';
 import Hammer from '../../module/hammer';
 import hammerUtil from '../../hammerUtil';
@@ -55,7 +55,7 @@ class ManipulationSystem {
         borderWidthSelected: 2
       }
     };
-    util.extend(this.options, this.defaultOptions);
+    Object.assign(this.options, this.defaultOptions);
 
     this.body.emitter.on('destroy',     () => {this._clean();});
     this.body.emitter.on('_dataChanged',this._restore.bind(this));
@@ -97,7 +97,7 @@ class ManipulationSystem {
       }
       else {
         this.options.enabled = true;
-        util.deepExtend(this.options, options);
+        deepExtend(this.options, options);
       }
       if (this.options.initiallyActive === true) {
         this.editMode = true;
@@ -280,7 +280,7 @@ class ManipulationSystem {
       this.inMode = 'editNode';
       if (typeof this.options.editNode === 'function') {
         if (node.isCluster !== true) {
-          let data = util.deepExtend({}, node.options, false);
+          let data = deepExtend({}, node.options, false);
           data.x = node.x;
           data.y = node.y;
 
@@ -565,7 +565,7 @@ class ManipulationSystem {
    * @private
    */
   _getNewTargetNode(x,y) {
-    let controlNodeStyle = util.deepExtend({}, this.options.controlNodeStyle);
+    let controlNodeStyle = deepExtend({}, this.options.controlNodeStyle);
 
     controlNodeStyle.id = 'targetNode' + randomUUID();
     controlNodeStyle.hidden = false;
@@ -592,7 +592,7 @@ class ManipulationSystem {
     this.manipulationDOM = {};
 
     // empty the editModeDiv
-    util.recursiveDOMDelete(this.editModeDiv);
+    recursiveDOMDelete(this.editModeDiv);
 
 
     // create the contents for the editMode button
@@ -615,8 +615,8 @@ class ManipulationSystem {
 
     // _clean the divs
     if (this.guiEnabled === true) {
-      util.recursiveDOMDelete(this.editModeDiv);
-      util.recursiveDOMDelete(this.manipulationDiv);
+      recursiveDOMDelete(this.editModeDiv);
+      recursiveDOMDelete(this.manipulationDiv);
 
       // removes all the bindings and overloads
       this._cleanManipulatorHammers();
@@ -660,9 +660,9 @@ class ManipulationSystem {
     this._clean();
 
     // empty the manipulation divs
-    util.recursiveDOMDelete(this.manipulationDiv);
-    util.recursiveDOMDelete(this.editModeDiv);
-    util.recursiveDOMDelete(this.closeDiv);
+    recursiveDOMDelete(this.manipulationDiv);
+    recursiveDOMDelete(this.editModeDiv);
+    recursiveDOMDelete(this.closeDiv);
 
     // remove the manipulation divs
     if (this.manipulationDiv) {this.canvas.frame.removeChild(this.manipulationDiv);}
@@ -895,7 +895,7 @@ class ManipulationSystem {
   _controlNodeTouch(event) {
     this.selectionHandler.unselectAll();
     this.lastTouch = this.body.functions.getPointer(event.center);
-    this.lastTouch.translation = util.extend({},this.body.view.translation); // copy the object
+    this.lastTouch.translation = Object.assign({},this.body.view.translation); // copy the object
   }
 
 
@@ -1015,7 +1015,7 @@ class ManipulationSystem {
     // check to avoid double fireing of this function.
     if (new Date().valueOf() - this.touchTime > 100) {
       this.lastTouch = this.body.functions.getPointer(event.center);
-      this.lastTouch.translation = util.extend({},this.body.view.translation); // copy the object
+      this.lastTouch.translation = Object.assign({},this.body.view.translation); // copy the object
 
       this.interactionHandler.drag.pointer = this.lastTouch; // Drag pointer is not updated when adding edges
       this.interactionHandler.drag.translation = this.lastTouch.translation;

--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -1,4 +1,4 @@
-import * as util from 'vis-util/esnext';
+import { bridgeObject, forEach } from 'vis-util/esnext';
 import { DataSet, DataView } from 'vis-data/esnext';
 import Node from "./components/Node";
 
@@ -147,7 +147,7 @@ class NodesHandler {
       throw 'Internal error: mass in defaultOptions of NodesHandler may not be zero or negative';
     }
 
-    this.options = util.bridgeObject(this.defaultOptions);
+    this.options = bridgeObject(this.defaultOptions);
 
     this.bindEventListeners();
   }
@@ -160,7 +160,7 @@ class NodesHandler {
     this.body.emitter.on('refreshNodes', this.refresh.bind(this));
     this.body.emitter.on('refresh', this.refresh.bind(this));
     this.body.emitter.on('destroy', () => {
-      util.forEach(this.nodesListeners, (callback, event) => {
+      forEach(this.nodesListeners, (callback, event) => {
         if (this.body.data.nodes)
           this.body.data.nodes.off(event, callback);
       });
@@ -253,7 +253,7 @@ class NodesHandler {
 
     if (oldNodesData) {
       // unsubscribe from old dataset
-      util.forEach(this.nodesListeners, function (callback, event) {
+      forEach(this.nodesListeners, function (callback, event) {
         oldNodesData.off(event, callback);
       });
     }
@@ -264,7 +264,7 @@ class NodesHandler {
     if (this.body.data.nodes) {
       // subscribe to new dataset
       let me = this;
-      util.forEach(this.nodesListeners, function (callback, event) {
+      forEach(this.nodesListeners, function (callback, event) {
         me.body.data.nodes.on(event, callback);
       });
 
@@ -382,7 +382,7 @@ class NodesHandler {
    * @param {boolean} [clearPositions=false]
    */
   refresh(clearPositions = false) {
-    util.forEach(this.body.nodes, (node, nodeId) => {
+    forEach(this.body.nodes, (node, nodeId) => {
       let data = this.body.data.nodes.get(nodeId);
       if (data !== undefined) {
         if (clearPositions === true) {

--- a/lib/network/modules/PhysicsEngine.js
+++ b/lib/network/modules/PhysicsEngine.js
@@ -6,7 +6,11 @@ import HierarchicalSpringSolver from './components/physics/HierarchicalSpringSol
 import CentralGravitySolver from './components/physics/CentralGravitySolver';
 import ForceAtlas2BasedRepulsionSolver from './components/physics/FA2BasedRepulsionSolver';
 import ForceAtlas2BasedCentralGravitySolver from './components/physics/FA2BasedCentralGravitySolver';
-import * as util from 'vis-util/esnext';
+import {
+  HSVToHex,
+  mergeOptions,
+  selectiveNotDeepExtend,
+} from 'vis-util/esnext';
 import { EndPoints } from './components/edges'; // for debugging with _drawForces()
 
 
@@ -91,7 +95,7 @@ class PhysicsEngine {
       adaptiveTimestep: true,
       wind: { x: 0, y: 0 }
     };
-    util.extend(this.options, this.defaultOptions);
+    Object.assign(this.options, this.defaultOptions);
     this.timestep = 0.5;
     this.layoutFailed = false;
 
@@ -150,8 +154,8 @@ class PhysicsEngine {
       }
       else {
         this.physicsEnabled = true;
-        util.selectiveNotDeepExtend(['stabilization'], this.options, options);
-        util.mergeOptions(this.options, options, 'stabilization');
+        selectiveNotDeepExtend(['stabilization'], this.options, options);
+        mergeOptions(this.options, options, 'stabilization');
 
         if (options.enabled === undefined) {
           this.options.enabled = true;
@@ -785,7 +789,7 @@ class PhysicsEngine {
       let size = Math.min(Math.max(5,forceSize),15);
       let arrowSize = 3*size;
 
-      let color = util.HSVToHex((180 - Math.min(1,Math.max(0,colorFactor*forceSize))*180) / 360,1,1);
+      let color = HSVToHex((180 - Math.min(1,Math.max(0,colorFactor*forceSize))*180) / 360,1,1);
 
       let point = {
         x: node.x + factor*force.x,

--- a/lib/network/modules/SelectionHandler.js
+++ b/lib/network/modules/SelectionHandler.js
@@ -1,7 +1,7 @@
 import Node from './components/Node';
 import Edge from './components/Edge';
 
-import * as util from 'vis-util/esnext';
+import { selectiveDeepExtend } from 'vis-util/esnext';
 
 /**
  * The handler for selections
@@ -24,7 +24,7 @@ class SelectionHandler {
       selectConnectedEdges: true,
       hoverConnectedEdges: true
     };
-    util.extend(this.options, this.defaultOptions);
+    Object.assign(this.options, this.defaultOptions);
 
     this.body.emitter.on("_dataChanged", () => {
       this.updateSelection()
@@ -39,7 +39,7 @@ class SelectionHandler {
   setOptions(options) {
     if (options !== undefined) {
       let fields = ['multiselect', 'hoverConnectedEdges', 'selectable', 'selectConnectedEdges'];
-      util.selectiveDeepExtend(fields, this.options, options);
+      selectiveDeepExtend(fields, this.options, options);
     }
   }
 

--- a/lib/network/modules/View.js
+++ b/lib/network/modules/View.js
@@ -1,4 +1,4 @@
-import * as util from 'vis-util/esnext';
+import { easingFunctions } from 'vis-util/esnext';
 
 import NetworkUtil from '../NetworkUtil';
 
@@ -328,7 +328,7 @@ class View {
     this.easingTime += this.animationSpeed;
     this.easingTime = finished === true ? 1.0 : this.easingTime;
 
-    let progress = util.easingFunctions[this.animationEasingFunction](this.easingTime);
+    let progress = easingFunctions[this.animationEasingFunction](this.easingTime);
 
     this.body.view.scale = this.sourceScale + (this.targetScale - this.sourceScale) * progress;
     this.body.view.translation = {

--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -1,6 +1,17 @@
-import * as util from 'vis-util/esnext';
+import {
+  bridgeObject,
+  deepExtend,
+  isString,
+  mergeOptions,
+  selectiveDeepExtend,
+} from 'vis-util/esnext';
 import Label from './shared/Label';
-import ComponentUtil from './shared/ComponentUtil';
+import {
+  choosify,
+  getSelfRefCoordinates,
+  isValidLabel,
+  pointInRect,
+} from './shared/ComponentUtil';
 import { BezierEdgeDynamic, BezierEdgeStatic, CubicBezierEdge, StraightEdge } from './edges';
 
 /**
@@ -22,7 +33,7 @@ class Edge {
     // Since globalOptions is constant in values as well as reference,
     // Following needs to be done only once.
 
-    this.options = util.bridgeObject(globalOptions);
+    this.options = bridgeObject(globalOptions);
     this.globalOptions = globalOptions;
     this.defaultOptions = defaultOptions;
     this.body = body;
@@ -89,7 +100,7 @@ class Edge {
     }
 
     let pile = [options, this.options, this.defaultOptions];
-    this.chooser = ComponentUtil.choosify('edge', pile);
+    this.chooser = choosify('edge', pile);
 
     // update label Module
     this.updateLabelModule(options);
@@ -142,7 +153,7 @@ class Edge {
     ];
 
     // only deep extend the items in the field array. These do not have shorthand.
-    util.selectiveDeepExtend(fields, parentOptions, newOptions, allowDeletion);
+    selectiveDeepExtend(fields, parentOptions, newOptions, allowDeletion);
 
     // Only use endPointOffset values (from and to) if it's valid values
     if (newOptions.endPointOffset !== undefined && newOptions.endPointOffset.from !== undefined) {
@@ -164,15 +175,15 @@ class Edge {
     }
 
     // Only copy label if it's a legal value.
-    if (ComponentUtil.isValidLabel(newOptions.label)) {
+    if (isValidLabel(newOptions.label)) {
       parentOptions.label = newOptions.label;
-    } else if (!ComponentUtil.isValidLabel(parentOptions.label)) {
+    } else if (!isValidLabel(parentOptions.label)) {
       parentOptions.label = undefined;
     }
 
-    util.mergeOptions(parentOptions, newOptions, 'smooth', globalOptions);
-    util.mergeOptions(parentOptions, newOptions, 'shadow', globalOptions);
-    util.mergeOptions(parentOptions, newOptions, 'background', globalOptions);
+    mergeOptions(parentOptions, newOptions, 'smooth', globalOptions);
+    mergeOptions(parentOptions, newOptions, 'shadow', globalOptions);
+    mergeOptions(parentOptions, newOptions, 'background', globalOptions);
 
     if (newOptions.dashes !== undefined && newOptions.dashes !== null) {
       parentOptions.dashes = newOptions.dashes;
@@ -185,7 +196,7 @@ class Edge {
     if (newOptions.scaling !== undefined && newOptions.scaling !== null) {
       if (newOptions.scaling.min !== undefined) {parentOptions.scaling.min = newOptions.scaling.min;}
       if (newOptions.scaling.max !== undefined) {parentOptions.scaling.max = newOptions.scaling.max;}
-      util.mergeOptions(parentOptions.scaling, newOptions.scaling, 'label', globalOptions.scaling);
+      mergeOptions(parentOptions.scaling, newOptions.scaling, 'label', globalOptions.scaling);
     }
     else if (allowDeletion === true && newOptions.scaling === null) {
       parentOptions.scaling = Object.create(globalOptions.scaling); // this sets the pointer of the option back to the global option.
@@ -200,9 +211,9 @@ class Edge {
         parentOptions.arrows.from.enabled   = arrows.indexOf("from")   != -1;
       }
       else if (typeof newOptions.arrows === 'object') {
-        util.mergeOptions(parentOptions.arrows, newOptions.arrows, 'to',     globalOptions.arrows);
-        util.mergeOptions(parentOptions.arrows, newOptions.arrows, 'middle', globalOptions.arrows);
-        util.mergeOptions(parentOptions.arrows, newOptions.arrows, 'from',   globalOptions.arrows);
+        mergeOptions(parentOptions.arrows, newOptions.arrows, 'to',     globalOptions.arrows);
+        mergeOptions(parentOptions.arrows, newOptions.arrows, 'middle', globalOptions.arrows);
+        mergeOptions(parentOptions.arrows, newOptions.arrows, 'from',   globalOptions.arrows);
       }
       else {
         throw new Error("The arrow newOptions can only be an object or a string. Refer to the documentation. You used:" + JSON.stringify(newOptions.arrows));
@@ -214,7 +225,7 @@ class Edge {
 
     // handle multiple input cases for color
     if (newOptions.color !== undefined && newOptions.color !== null) {
-      const fromColor = util.isString(newOptions.color)
+      const fromColor = isString(newOptions.color)
         ? {
           color: newOptions.color,
           highlight: newOptions.color,
@@ -227,7 +238,7 @@ class Edge {
 
       // If passed, fill in values from default options - required in the case of no prototype bridging
       if (copyFromGlobals) {
-        util.deepExtend(toColor, globalOptions.color, false, allowDeletion);
+        deepExtend(toColor, globalOptions.color, false, allowDeletion);
       } else {
         // Clear local properties - need to do it like this in order to retain prototype bridges
         for (var i in toColor) {
@@ -237,7 +248,7 @@ class Edge {
         }
       }
 
-      if (util.isString(toColor)) {
+      if (isString(toColor)) {
         toColor.color     = toColor;
         toColor.highlight = toColor;
         toColor.hover     = toColor;
@@ -264,11 +275,11 @@ class Edge {
       }
     }
     else if (allowDeletion === true && newOptions.color === null) {
-      parentOptions.color = util.bridgeObject(globalOptions.color); // set the object back to the global options
+      parentOptions.color = bridgeObject(globalOptions.color); // set the object back to the global options
     }
 
     if (allowDeletion === true && newOptions.font === null) {
-      parentOptions.font = util.bridgeObject(globalOptions.font); // set the object back to the global options
+      parentOptions.font = bridgeObject(globalOptions.font); // set the object back to the global options
     }
 
     if(newOptions.hasOwnProperty("selfReferenceSize")){
@@ -714,7 +725,7 @@ class Edge {
         this.labelModule.pointToSelf = true;
 
         // get circle coordinates
-        const coordinates = ComponentUtil.getSelfRefCoordinates(
+        const coordinates = getSelfRefCoordinates(
           ctx,
           this.options.selfReference.angle,
           this.options.selfReference.size,
@@ -746,7 +757,7 @@ class Edge {
 
     if (this.labelModule.visible()) {
       let rotationPoint = this._getRotation();
-      if (ComponentUtil.pointInRect(this.labelModule.getSize(), point, rotationPoint)) {
+      if (pointInRect(this.labelModule.getSize(), point, rotationPoint)) {
         ret.push({edgeId:this.id, labelId:0});
       }
     }

--- a/lib/network/modules/components/NavigationHandler.js
+++ b/lib/network/modules/components/NavigationHandler.js
@@ -1,7 +1,7 @@
 import './NavigationHandler.css';
 
 import Hammer from '../../../module/hammer';
-import hammerUtil from '../../../hammerUtil';
+import { onRelease, onTouch } from '../../../hammerUtil';
 import keycharm from 'keycharm';
 
 /**
@@ -103,10 +103,10 @@ class NavigationHandler {
 
       var hammer = new Hammer(this.navigationDOM[navigationDivs[i]]);
       if (navigationDivActions[i] === "_fit") {
-        hammerUtil.onTouch(hammer, this._fit.bind(this));
+        onTouch(hammer, this._fit.bind(this));
       }
       else {
-        hammerUtil.onTouch(hammer, this.bindToRedraw.bind(this,navigationDivActions[i]));
+        onTouch(hammer, this.bindToRedraw.bind(this,navigationDivActions[i]));
       }
 
       this.navigationHammers.push(hammer);
@@ -115,7 +115,7 @@ class NavigationHandler {
     // use a hammer for the release so we do not require the one used in the rest of the network
     // the one the rest uses can be overloaded by the manipulation system.
     var hammerFrame = new Hammer(this.canvas.frame);
-    hammerUtil.onRelease(hammerFrame, () => {this._stopMovement();});
+    onRelease(hammerFrame, () => {this._stopMovement();});
     this.navigationHammers.push(hammerFrame);
 
     this.iconsCreated = true;

--- a/lib/network/modules/components/Node.js
+++ b/lib/network/modules/components/Node.js
@@ -1,7 +1,14 @@
-import * as util from 'vis-util/esnext';
+import {
+  bridgeObject,
+  fillIfDefined,
+  mergeOptions,
+  overrideOpacity,
+  parseColor,
+  selectiveNotDeepExtend,
+} from 'vis-util/esnext';
 
 import Label from './shared/Label';
-import ComponentUtil from './shared/ComponentUtil';
+import { choosify, pointInRect } from './shared/ComponentUtil';
 import Box from './nodes/shapes/Box';
 import Circle from './nodes/shapes/Circle';
 import CircularImage from './nodes/shapes/CircularImage';
@@ -45,7 +52,7 @@ class Node {
    *                                    for parameter `globalOptions`.
    */
   constructor(options, body, imagelist, grouplist, globalOptions, defaultOptions) {
-    this.options = util.bridgeObject(globalOptions);
+    this.options = bridgeObject(globalOptions);
     this.globalOptions = globalOptions;
     this.defaultOptions = defaultOptions;
     this.body = body;
@@ -142,7 +149,7 @@ class Node {
     Node.parseOptions(this.options, options, true, this.globalOptions, this.grouplist);
     
     let pile = [options, this.options, this.defaultOptions];
-    this.chooser = ComponentUtil.choosify('node', pile);
+    this.chooser = choosify('node', pile);
 
     
 
@@ -251,11 +258,11 @@ class Node {
     const skipProperties = Object.getOwnPropertyNames(newOptions).filter(p => newOptions[p] != null);
     // Always skip merging group font options into parent; these are required to be distinct for labels
     skipProperties.push('font');
-    util.selectiveNotDeepExtend(skipProperties, parentOptions, groupObj);
+    selectiveNotDeepExtend(skipProperties, parentOptions, groupObj);
 
     // the color object needs to be completely defined.
     // Since groups can partially overwrite the colors, we parse it again, just in case.
-    parentOptions.color = util.parseColor(parentOptions.color);
+    parentOptions.color = parseColor(parentOptions.color);
   }
 
 
@@ -276,7 +283,7 @@ class Node {
       'fixed',
       'shadow'
     ];
-    util.selectiveNotDeepExtend(fields, parentOptions, newOptions, allowDeletion);
+    selectiveNotDeepExtend(fields, parentOptions, newOptions, allowDeletion);
 
     Node.checkMass(newOptions);
 
@@ -296,15 +303,15 @@ class Node {
     }
 
     // merge the shadow options into the parent.
-    util.mergeOptions(parentOptions, newOptions, 'shadow', globalOptions);
+    mergeOptions(parentOptions, newOptions, 'shadow', globalOptions);
 
     // individual shape newOptions
     if (newOptions.color !== undefined && newOptions.color !== null) {
-      let parsedColor = util.parseColor(newOptions.color);
-      util.fillIfDefined(parentOptions.color, parsedColor);
+      let parsedColor = parseColor(newOptions.color);
+      fillIfDefined(parentOptions.color, parsedColor);
     }
     else if (allowDeletion === true && newOptions.color === null) {
-      parentOptions.color = util.bridgeObject(globalOptions.color); // set the object back to the global options
+      parentOptions.color = bridgeObject(globalOptions.color); // set the object back to the global options
     }
 
     // handle the fixed options
@@ -324,14 +331,14 @@ class Node {
     }
 
     if (allowDeletion === true && newOptions.font === null) {
-      parentOptions.font =  util.bridgeObject(globalOptions.font); // set the object back to the global options
+      parentOptions.font =  bridgeObject(globalOptions.font); // set the object back to the global options
     }
 
     Node.updateGroupOptions(parentOptions, newOptions, groupList);
 
     // handle the scaling options, specifically the label part
     if (newOptions.scaling !== undefined) {
-      util.mergeOptions(parentOptions.scaling, newOptions.scaling, 'label', globalOptions.scaling);
+      mergeOptions(parentOptions.scaling, newOptions.scaling, 'label', globalOptions.scaling);
     }
   }
 
@@ -383,9 +390,9 @@ class Node {
     }
     if (this.options.opacity !== undefined) {
       const opacity = this.options.opacity;
-      values.borderColor = util.overrideOpacity(values.borderColor, opacity);
-      values.color = util.overrideOpacity(values.color, opacity);
-      values.shadowColor = util.overrideOpacity(values.shadowColor, opacity);
+      values.borderColor = overrideOpacity(values.borderColor, opacity);
+      values.color = overrideOpacity(values.color, opacity);
+      values.shadowColor = overrideOpacity(values.shadowColor, opacity);
     }
     return values;
   }
@@ -653,12 +660,12 @@ class Node {
     var ret = [];
 
     if (this.labelModule.visible()) {
-      if (ComponentUtil.pointInRect(this.labelModule.getSize(), point)) {
+      if (pointInRect(this.labelModule.getSize(), point)) {
         ret.push({nodeId:this.id, labelId:0});
       }
     }
 
-    if (ComponentUtil.pointInRect(this.shape.boundingBox, point)) {
+    if (pointInRect(this.shape.boundingBox, point)) {
       ret.push({nodeId:this.id});
     }
 

--- a/lib/network/modules/components/edges/util/edge-base.ts
+++ b/lib/network/modules/components/edges/util/edge-base.ts
@@ -16,7 +16,7 @@ import {
   VNode
 } from "./types";
 import { drawDashedLine } from "./shapes";
-import * as ComponentUtil from "./../../shared/ComponentUtil";
+import { getSelfRefCoordinates } from "../../shared/ComponentUtil";
 
 export interface FindBorderPositionOptions<Via> {
   via: Via;
@@ -329,7 +329,7 @@ export abstract class EdgeBase<Via = undefined> implements EdgeType {
     }
 
     // get circle coordinates
-    const coordinates = ComponentUtil.default.getSelfRefCoordinates(
+    const coordinates = getSelfRefCoordinates(
       ctx,
       this.options.selfReference.angle,
       radius,

--- a/lib/network/modules/components/nodes/Cluster.js
+++ b/lib/network/modules/components/nodes/Cluster.js
@@ -1,4 +1,4 @@
-import * as util from 'vis-util/esnext';
+import { forEach } from 'vis-util/esnext';
 import Node from "../Node";
 
 /**
@@ -43,30 +43,30 @@ class Cluster extends Node {
 
     // Disconnect child cluster from current cluster
     delete this.containedNodes[childClusterId];
-    util.forEach(childCluster.edges, (edge) => {
+    forEach(childCluster.edges, (edge) => {
       delete this.containedEdges[edge.id];
     });
 
     // Transfer nodes and edges
-    util.forEach(childCluster.containedNodes, (node, nodeId) => {
+    forEach(childCluster.containedNodes, (node, nodeId) => {
       this.containedNodes[nodeId] = node;
     });
     childCluster.containedNodes = {};
 
-    util.forEach(childCluster.containedEdges, (edge, edgeId) => {
+    forEach(childCluster.containedEdges, (edge, edgeId) => {
       this.containedEdges[edgeId] = edge;
     });
     childCluster.containedEdges = {};
 
     // Transfer edges within cluster edges which are clustered
-    util.forEach(childCluster.edges, (clusterEdge) => {
-      util.forEach(this.edges, (parentClusterEdge) => {
+    forEach(childCluster.edges, (clusterEdge) => {
+      forEach(this.edges, (parentClusterEdge) => {
         // Assumption: a clustered edge can only be present in a single clustering edge
         // Not tested here
         let index = parentClusterEdge.clusteringEdgeReplacingIds.indexOf(clusterEdge.id);
         if (index === -1) return;
 
-        util.forEach(clusterEdge.clusteringEdgeReplacingIds, (srcId) => {
+        forEach(clusterEdge.clusteringEdgeReplacingIds, (srcId) => {
           parentClusterEdge.clusteringEdgeReplacingIds.push(srcId);
 
           // Maintain correct bookkeeping for transferred edge

--- a/lib/network/modules/components/shared/ComponentUtil.js
+++ b/lib/network/modules/components/shared/ComponentUtil.js
@@ -1,10 +1,9 @@
-import * as util from 'vis-util/esnext';
+import { topMost } from 'vis-util/esnext';
 
 /**
  * Helper functions for components
- * @class
  */
-class ComponentUtil {
+
   /**
    * Determine values to use for (sub)options of 'chosen'.
    *
@@ -27,12 +26,12 @@ class ComponentUtil {
    * 
    * @return {boolean|function}  value for passed subOption of 'chosen' to use
    */
-  static choosify(subOption, pile) {
+  export function choosify(subOption, pile) {
     // allowed values for subOption
     let allowed = [ 'node', 'edge', 'label'];
     let value = true;
 
-    let chosen = util.topMost(pile, 'chosen');
+    let chosen = topMost(pile, 'chosen');
     if (typeof chosen === 'boolean') {
       value = chosen;
     } else if (typeof chosen === 'object') {
@@ -41,7 +40,7 @@ class ComponentUtil {
           + "'" + allowed.join("', '") +  "'");
       }
 
-      let chosenEdge = util.topMost(pile, ['chosen', subOption]);
+      let chosenEdge = topMost(pile, ['chosen', subOption]);
       if ((typeof chosenEdge === 'boolean') || (typeof chosenEdge === 'function')) {
         value = chosenEdge;
       }
@@ -58,9 +57,8 @@ class ComponentUtil {
    * @param {point} point
    * @param {rotationPoint} [rotationPoint] if specified, the rotation that applies to the rectangle.
    * @returns {boolean}  true if point within rectangle, false otherwise
-   * @static
    */
-  static pointInRect(rect, point, rotationPoint) {
+  export function pointInRect(rect, point, rotationPoint) {
     if (rect.width <= 0 || rect.height <= 0) {
       return false;  // early out
     }
@@ -110,7 +108,7 @@ class ComponentUtil {
    * @param {*} text value to check; can be anything at this point
    * @returns {boolean} true if valid label value, false otherwise
    */
-  static isValidLabel(text) {
+  export function isValidLabel(text) {
     // Note that this is quite strict: types that *might* be converted to string are disallowed
     return  (typeof text === 'string' && text !== '');
   }
@@ -124,7 +122,7 @@ class ComponentUtil {
    * @return {Object} node
    * @returns {Object} x and y coordinates
    */
-  static getSelfRefCoordinates(ctx, angle, radius, node){
+  export function getSelfRefCoordinates(ctx, angle, radius, node){
     let x = node.x;
     let y = node.y;
     
@@ -161,7 +159,3 @@ class ComponentUtil {
     
     return {x,y};
   }
-
-}
-
-export default ComponentUtil;

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -1,5 +1,10 @@
-import * as util from 'vis-util/esnext';
-import ComponentUtil from './ComponentUtil';
+import {
+  deepExtend,
+  forEach,
+  overrideOpacity,
+  topMost,
+} from 'vis-util/esnext';
+import { choosify, isValidLabel } from './ComponentUtil';
 import LabelSplitter from './LabelSplitter';
 
 
@@ -39,7 +44,7 @@ class Label {
 
     this.initFontOptions(options.font);
 
-    if (ComponentUtil.isValidLabel(options.label)) {
+    if (isValidLabel(options.label)) {
       this.labelDirty = true;
     } else {
       // Bad label! Change the option value to prevent bad stuff happening
@@ -73,7 +78,7 @@ class Label {
   initFontOptions(newFontOptions) {
     // Prepare the multi-font option objects.
     // These will be filled in propagateFonts(), if required
-    util.forEach(multiFontStyle, (style) => {
+    forEach(multiFontStyle, (style) => {
       this.fontOptions[style] = {};
     });
 
@@ -84,7 +89,7 @@ class Label {
     }
 
     // Copy over the non-multifont options, if specified
-    util.forEach(newFontOptions, (prop, n) => {
+    forEach(newFontOptions, (prop, n) => {
       if (prop !== undefined && prop !== null && typeof prop !== 'object') {
         this.fontOptions[n] = prop;
       }
@@ -136,31 +141,31 @@ class Label {
       valign: 'middle',
     }
 
-    let widthConstraint = util.topMost(pile, 'widthConstraint');
+    let widthConstraint = topMost(pile, 'widthConstraint');
     if (typeof widthConstraint === 'number') {
       fontOptions.maxWdt = Number(widthConstraint);
       fontOptions.minWdt = Number(widthConstraint);
     } else if (typeof widthConstraint === 'object') {
-      let widthConstraintMaximum = util.topMost(pile, ['widthConstraint', 'maximum']);
+      let widthConstraintMaximum = topMost(pile, ['widthConstraint', 'maximum']);
       if (typeof widthConstraintMaximum === 'number') {
         fontOptions.maxWdt = Number(widthConstraintMaximum);
       }
-      let widthConstraintMinimum = util.topMost(pile, ['widthConstraint', 'minimum'])
+      let widthConstraintMinimum = topMost(pile, ['widthConstraint', 'minimum'])
       if (typeof widthConstraintMinimum === 'number') {
         fontOptions.minWdt = Number(widthConstraintMinimum);
       }
     }
 
 
-    let heightConstraint = util.topMost(pile, 'heightConstraint');
+    let heightConstraint = topMost(pile, 'heightConstraint');
     if (typeof heightConstraint === 'number') {
       fontOptions.minHgt = Number(heightConstraint);
     } else if (typeof heightConstraint === 'object') {
-      let heightConstraintMinimum = util.topMost(pile, ['heightConstraint', 'minimum']);
+      let heightConstraintMinimum = topMost(pile, ['heightConstraint', 'minimum']);
       if (typeof heightConstraintMinimum === 'number') {
         fontOptions.minHgt = Number(heightConstraintMinimum);
       }
-      let heightConstraintValign = util.topMost(pile, ['heightConstraint', 'valign']);
+      let heightConstraintValign = topMost(pile, ['heightConstraint', 'valign']);
       if (typeof heightConstraintValign === 'string') {
         if ((heightConstraintValign === 'top')|| (heightConstraintValign === 'bottom')) {
           fontOptions.valign = heightConstraintValign;
@@ -181,8 +186,8 @@ class Label {
   update(options, pile) {
     this.setOptions(options, true);
     this.propagateFonts(pile);
-    util.deepExtend(this.fontOptions, this.constrain(pile));
-    this.fontOptions.chooser = ComponentUtil.choosify('label', pile);
+    deepExtend(this.fontOptions, this.constrain(pile));
+    this.fontOptions.chooser = choosify('label', pile);
   }
 
 
@@ -261,7 +266,7 @@ class Label {
         fontOptions = tmpShorthand;
       }
 
-      util.forEach(fontOptions, (opt, name) => {
+      forEach(fontOptions, (opt, name) => {
         if (opt === undefined) return;        // multi-font option need not be present 
         if (ret.hasOwnProperty(name)) return; // Keep first value we encounter
 
@@ -388,7 +393,7 @@ class Label {
       let tmpMultiFontOptions = this.getFontOptions(fontPile, mod);
 
       // Copy over found values
-      util.forEach(tmpMultiFontOptions, (option, n) => {
+      forEach(tmpMultiFontOptions, (option, n) => {
         modOptions[n] = option;
       });
 
@@ -549,8 +554,8 @@ class Label {
     let strokeColor = initialStrokeColor || '#ffffff';
     if (viewFontSize <= this.elementOptions.scaling.label.drawThreshold) {
       let opacity = Math.max(0, Math.min(1, 1 - (this.elementOptions.scaling.label.drawThreshold - viewFontSize)));
-      fontColor = util.overrideOpacity(fontColor, opacity);
-      strokeColor = util.overrideOpacity(strokeColor, opacity);
+      fontColor = overrideOpacity(fontColor, opacity);
+      strokeColor = overrideOpacity(strokeColor, opacity);
     }
     return [fontColor, strokeColor];
   }

--- a/lib/network/modules/components/shared/LabelSplitter.js
+++ b/lib/network/modules/components/shared/LabelSplitter.js
@@ -1,5 +1,5 @@
 import LabelAccumulator from './LabelAccumulator';
-import ComponentUtil from './ComponentUtil';
+import { isValidLabel } from './ComponentUtil';
 
 // Hash of prepared regexp's for tags
 var tagPattern = {
@@ -339,7 +339,7 @@ class LabelSplitter {
    * @returns {Array<line>}
    */
   process(text) {
-    if (!ComponentUtil.isValidLabel(text)) {
+    if (!isValidLabel(text)) {
       return this.lines.finalize();
     }
 

--- a/lib/shared/Activator.js
+++ b/lib/shared/Activator.js
@@ -1,9 +1,9 @@
-require('./Activator.css');
+import "./Activator.css";
 
-var keycharm = require('keycharm');
-var Emitter = require('component-emitter');
-var Hammer = require('../module/hammer');
-var util = require('vis-util');
+import keycharm from "keycharm";
+import Emitter from "component-emitter";
+import Hammer from "../module/hammer";
+import { addClassName, removeClassName } from "vis-util/esnext";
 
 /**
  * Turn an element into an clickToUse element.
@@ -104,7 +104,7 @@ Activator.prototype.activate = function () {
 
   this.active = true;
   this.dom.overlay.style.display = 'none';
-  util.addClassName(this.dom.container, 'vis-active');
+  addClassName(this.dom.container, 'vis-active');
 
   this.emit('change');
   this.emit('activate');
@@ -121,7 +121,7 @@ Activator.prototype.activate = function () {
 Activator.prototype.deactivate = function () {
   this.active = false;
   this.dom.overlay.style.display = 'block';
-  util.removeClassName(this.dom.container, 'vis-active');
+  removeClassName(this.dom.container, 'vis-active');
   this.keycharm.unbind('esc', this.escListener);
 
   this.emit('change');
@@ -158,4 +158,5 @@ function _hasParent(element, parent) {
   return false;
 }
 
-module.exports = Activator;
+export default Activator;
+export { Activator };

--- a/lib/shared/ColorPicker.js
+++ b/lib/shared/ColorPicker.js
@@ -1,7 +1,7 @@
 import './ColorPicker.css';
 
 import Hammer from '../module/hammer';
-import hammerUtil from '../hammerUtil';
+import { onTouch } from '../hammerUtil';
 import {
   HSVToRGB,
   RGBToHSV,
@@ -478,7 +478,7 @@ class ColorPicker {
     this.hammer = new Hammer(this.colorPickerCanvas);
     this.hammer.get('pinch').set({enable: true});
 
-    hammerUtil.onTouch(this.hammer, (event) => {this._moveSelector(event)});
+    onTouch(this.hammer, (event) => {this._moveSelector(event)});
     this.hammer.on('tap',       (event) => {this._moveSelector(event)});
     this.hammer.on('panstart',  (event) => {this._moveSelector(event)});
     this.hammer.on('panmove',   (event) => {this._moveSelector(event)});

--- a/lib/shared/ColorPicker.js
+++ b/lib/shared/ColorPicker.js
@@ -2,7 +2,15 @@ import './ColorPicker.css';
 
 import Hammer from '../module/hammer';
 import hammerUtil from '../hammerUtil';
-import * as util from 'vis-util/esnext';
+import {
+  HSVToRGB,
+  RGBToHSV,
+  hexToRGB,
+  isString,
+  isValidHex,
+  isValidRGB,
+  isValidRGBA,
+} from 'vis-util/esnext';
 
 
 var htmlColors = {black: '#000000', navy: '#000080', darkblue: '#00008B', mediumblue: '#0000CD', blue: '#0000FF', darkgreen: '#006400', green: '#008000', teal: '#008080', darkcyan: '#008B8B', deepskyblue: '#00BFFF', darkturquoise: '#00CED1', mediumspringgreen: '#00FA9A', lime: '#00FF00', springgreen: '#00FF7F', aqua: '#00FFFF', cyan: '#00FFFF', midnightblue: '#191970', dodgerblue: '#1E90FF', lightseagreen: '#20B2AA', forestgreen: '#228B22', seagreen: '#2E8B57', darkslategray: '#2F4F4F', limegreen: '#32CD32', mediumseagreen: '#3CB371', turquoise: '#40E0D0', royalblue: '#4169E1', steelblue: '#4682B4', darkslateblue: '#483D8B', mediumturquoise: '#48D1CC', indigo: '#4B0082', darkolivegreen: '#556B2F', cadetblue: '#5F9EA0', cornflowerblue: '#6495ED', mediumaquamarine: '#66CDAA', dimgray: '#696969', slateblue: '#6A5ACD', olivedrab: '#6B8E23', slategray: '#708090', lightslategray: '#778899', mediumslateblue: '#7B68EE', lawngreen: '#7CFC00', chartreuse: '#7FFF00', aquamarine: '#7FFFD4', maroon: '#800000', purple: '#800080', olive: '#808000', gray: '#808080', skyblue: '#87CEEB', lightskyblue: '#87CEFA', blueviolet: '#8A2BE2', darkred: '#8B0000', darkmagenta: '#8B008B', saddlebrown: '#8B4513', darkseagreen: '#8FBC8F', lightgreen: '#90EE90', mediumpurple: '#9370D8', darkviolet: '#9400D3', palegreen: '#98FB98', darkorchid: '#9932CC', yellowgreen: '#9ACD32', sienna: '#A0522D', brown: '#A52A2A', darkgray: '#A9A9A9', lightblue: '#ADD8E6', greenyellow: '#ADFF2F', paleturquoise: '#AFEEEE', lightsteelblue: '#B0C4DE', powderblue: '#B0E0E6', firebrick: '#B22222', darkgoldenrod: '#B8860B', mediumorchid: '#BA55D3', rosybrown: '#BC8F8F', darkkhaki: '#BDB76B', silver: '#C0C0C0', mediumvioletred: '#C71585', indianred: '#CD5C5C', peru: '#CD853F', chocolate: '#D2691E', tan: '#D2B48C', lightgrey: '#D3D3D3', palevioletred: '#D87093', thistle: '#D8BFD8', orchid: '#DA70D6', goldenrod: '#DAA520', crimson: '#DC143C', gainsboro: '#DCDCDC', plum: '#DDA0DD', burlywood: '#DEB887', lightcyan: '#E0FFFF', lavender: '#E6E6FA', darksalmon: '#E9967A', violet: '#EE82EE', palegoldenrod: '#EEE8AA', lightcoral: '#F08080', khaki: '#F0E68C', aliceblue: '#F0F8FF', honeydew: '#F0FFF0', azure: '#F0FFFF', sandybrown: '#F4A460', wheat: '#F5DEB3', beige: '#F5F5DC', whitesmoke: '#F5F5F5', mintcream: '#F5FFFA', ghostwhite: '#F8F8FF', salmon: '#FA8072', antiquewhite: '#FAEBD7', linen: '#FAF0E6', lightgoldenrodyellow: '#FAFAD2', oldlace: '#FDF5E6', red: '#FF0000', fuchsia: '#FF00FF', magenta: '#FF00FF', deeppink: '#FF1493', orangered: '#FF4500', tomato: '#FF6347', hotpink: '#FF69B4', coral: '#FF7F50', darkorange: '#FF8C00', lightsalmon: '#FFA07A', orange: '#FFA500', lightpink: '#FFB6C1', pink: '#FFC0CB', gold: '#FFD700', peachpuff: '#FFDAB9', navajowhite: '#FFDEAD', moccasin: '#FFE4B5', bisque: '#FFE4C4', mistyrose: '#FFE4E1', blanchedalmond: '#FFEBCD', papayawhip: '#FFEFD5', lavenderblush: '#FFF0F5', seashell: '#FFF5EE', cornsilk: '#FFF8DC', lemonchiffon: '#FFFACD', floralwhite: '#FFFAF0', snow: '#FFFAFA', yellow: '#FFFF00', lightyellow: '#FFFFE0', ivory: '#FFFFF0', white: '#FFFFFF'};
@@ -115,17 +123,17 @@ class ColorPicker {
     }
 
     // check format
-    if (util.isString(color) === true) {
-      if (util.isValidRGB(color) === true) {
+    if (isString(color) === true) {
+      if (isValidRGB(color) === true) {
         let rgbaArray = color.substr(4).substr(0, color.length - 5).split(',');
         rgba = {r:rgbaArray[0], g:rgbaArray[1], b:rgbaArray[2], a:1.0};
       }
-      else if (util.isValidRGBA(color) === true) {
+      else if (isValidRGBA(color) === true) {
         let rgbaArray = color.substr(5).substr(0, color.length - 6).split(',');
         rgba = {r:rgbaArray[0], g:rgbaArray[1], b:rgbaArray[2], a:rgbaArray[3]};
       }
-      else if (util.isValidHex(color) === true) {
-        let rgbObj = util.hexToRGB(color);
+      else if (isValidHex(color) === true) {
+        let rgbObj = hexToRGB(color);
         rgba = {r:rgbObj.r, g:rgbObj.g, b:rgbObj.b, a:1.0};
       }
     }
@@ -174,7 +182,7 @@ class ColorPicker {
   _hide(storePrevious = true) {
     // store the previous color for next time;
     if (storePrevious === true) {
-      this.previousColor = util.extend({}, this.color);
+      this.previousColor = Object.assign({}, this.color);
     }
 
     if (this.applied === true) {
@@ -239,11 +247,11 @@ class ColorPicker {
   _setColor(rgba, setInitial = true) {
     // store the initial color
     if (setInitial === true) {
-      this.initialColor = util.extend({}, rgba);
+      this.initialColor = Object.assign({}, rgba);
     }
 
     this.color = rgba;
-    let hsv = util.RGBToHSV(rgba.r, rgba.g, rgba.b);
+    let hsv = RGBToHSV(rgba.r, rgba.g, rgba.b);
 
     let angleConvert = 2 * Math.PI;
     let radius = this.r * hsv.s;
@@ -274,9 +282,9 @@ class ColorPicker {
    * @private
    */
   _setBrightness(value) {
-    let hsv = util.RGBToHSV(this.color.r, this.color.g, this.color.b);
+    let hsv = RGBToHSV(this.color.r, this.color.g, this.color.b);
     hsv.v = value / 100;
-    let rgba = util.HSVToRGB(hsv.h, hsv.s, hsv.v);
+    let rgba = HSVToRGB(hsv.h, hsv.s, hsv.v);
     rgba['a'] = this.color.a;
     this.color = rgba;
     this._updatePicker();
@@ -289,7 +297,7 @@ class ColorPicker {
    * @private
    */
   _updatePicker(rgba = this.color) {
-    let hsv = util.RGBToHSV(rgba.r, rgba.g, rgba.b);
+    let hsv = RGBToHSV(rgba.r, rgba.g, rgba.b);
     let ctx = this.colorPickerCanvas.getContext('2d');
     if (this.pixelRation === undefined) {
       this.pixelRatio = (window.devicePixelRatio || 1) / (ctx.webkitBackingStorePixelRatio ||
@@ -512,7 +520,7 @@ class ColorPicker {
         for (sat = 0; sat < this.r; sat++) {
           x = this.centerCoordinates.x + sat * Math.sin(angleConvert * hue);
           y = this.centerCoordinates.y + sat * Math.cos(angleConvert * hue);
-          rgb = util.HSVToRGB(hue * hfac, sat * sfac, 1);
+          rgb = HSVToRGB(hue * hfac, sat * sfac, 1);
           ctx.fillStyle = 'rgb(' + rgb.r + ',' + rgb.g + ',' + rgb.b + ')';
           ctx.fillRect(x - 0.5, y - 0.5, 2, 2);
         }
@@ -557,10 +565,10 @@ class ColorPicker {
     let h = angle / (2 * Math.PI);
     h = h < 0 ? h + 1 : h;
     let s = radius / this.r;
-    let hsv = util.RGBToHSV(this.color.r, this.color.g, this.color.b);
+    let hsv = RGBToHSV(this.color.r, this.color.g, this.color.b);
     hsv.h = h;
     hsv.s = s;
-    let rgba = util.HSVToRGB(hsv.h, hsv.s, hsv.v);
+    let rgba = HSVToRGB(hsv.h, hsv.s, hsv.v);
     rgba['a'] = this.color.a;
     this.color = rgba;
 

--- a/lib/shared/Configurator.js
+++ b/lib/shared/Configurator.js
@@ -1,6 +1,6 @@
 import './Configurator.css';
 
-import * as util from 'vis-util/esnext';
+import { copyAndExtendArray } from 'vis-util/esnext';
 
 import ColorPicker from './ColorPicker';
 
@@ -35,7 +35,7 @@ class Configurator {
       container: undefined,
       showButton: true
     };
-    util.extend(this.options, this.defaultOptions);
+    Object.assign(this.options, this.defaultOptions);
 
     this.configureOptions = configureOptions;
     this.moduleOptions = {};
@@ -583,7 +583,7 @@ class Configurator {
       if (obj.hasOwnProperty(subObj)) {
         show = true;
         let item = obj[subObj];
-        let newPath = util.copyAndExtendArray(path, subObj);
+        let newPath = copyAndExtendArray(path, subObj);
         if (typeof filter === 'function') {
           show = filter(subObj,path);
 
@@ -622,7 +622,7 @@ class Configurator {
             if (draw === true) {
               // initially collapse options with an disabled enabled option.
               if (item.enabled !== undefined) {
-                let enabledPath = util.copyAndExtendArray(newPath, 'enabled');
+                let enabledPath = copyAndExtendArray(newPath, 'enabled');
                 let enabledValue = this._getValue(enabledPath);
                 if (enabledValue === true) {
                   let label = this._makeLabel(subObj, newPath, true);

--- a/lib/shared/Validator.js
+++ b/lib/shared/Validator.js
@@ -1,4 +1,4 @@
-import * as util from 'vis-util/esnext';
+import { copyAndExtendArray, copyArray } from 'vis-util/esnext';
 
 let errorFound = false;
 let allOptions;
@@ -119,7 +119,7 @@ class Validator {
         errorFound = true;
       }
       else if (optionType === 'object' && referenceOption !== "__any__") {
-        path = util.copyAndExtendArray(path, option);
+        path = copyAndExtendArray(path, option);
         Validator.parse(options[option], referenceOptions[referenceOption], path);
       }
     }
@@ -237,7 +237,7 @@ class Validator {
     for (let op in options) {  // eslint-disable-line guard-for-in
       let distance;
       if (options[op].__type__ !== undefined && recursive === true) {
-        let result = Validator.findInOptions(option, options[op], util.copyAndExtendArray(path,op));
+        let result = Validator.findInOptions(option, options[op], copyAndExtendArray(path,op));
         if (min > result.distance) {
           closestMatch = result.closestMatch;
           closestMatchPath = result.path;
@@ -252,7 +252,7 @@ class Validator {
         distance = Validator.levenshteinDistance(option, op);
         if (min > distance) {
           closestMatch = op;
-          closestMatchPath = util.copyArray(path);
+          closestMatchPath = copyArray(path);
           min = distance;
         }
       }

--- a/test/Label.test.js
+++ b/test/Label.test.js
@@ -18,7 +18,7 @@ import canvasMockify from './canvas-mock';
 import Label from '../lib/network/modules/components/shared/Label';
 import NodesHandler from '../lib/network/modules/NodesHandler';
 import Network from '../lib/network/Network';
-import ComponentUtil from '../lib/network/modules/components/shared/ComponentUtil';
+import { isValidLabel } from '../lib/network/modules/components/shared/ComponentUtil';
 
 /**************************************************************
  * Dummy class definitions for minimal required functionality.
@@ -1626,7 +1626,7 @@ describe('Shorthand Font Options', function() {
     it('correctly determines label is not visible when label is invalid', function(done) {
       var invalidLabel = ''
       assert(
-        !ComponentUtil.isValidLabel(invalidLabel),
+        !isValidLabel(invalidLabel),
         'An empty string should be identified as an invalid label'
       )
 


### PR DESCRIPTION
Instead of using default or namespace import, named imports are used now, importing only what is actually being used. Some modules were also rewritten into ESM so that this makes any sense (named import from CJS is the same as `import * as X from Y; const { whatWeActuallyWant, /* the rest still can be accessed and therefore can't be tree shaken */ } = X;`).

This slims down the standalone build by 167 kB (due to an error in importing, we had two copies of Vis Util so only about 65 kB is thanks to named imports).

Since I was already refactoring this I got rid of `extend` and `toArray` as they're basically ES6 polyfills (literally implemented as `Object.assign()` and `Object.values()`).

This change somehow fixes #573. As for how: Some UMD modules were declared using `Object.assign()` in emitted code (I have no idea why, this may happen again in the future) which doesn't work in IE11, ESM doesn't seem to have this problem.