### PR TITLE
chore(readme): replace Greenkeeper badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,17 @@ Network is a visualization to display networks and networks consisting of nodes 
 
 ## Badges
 
-[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release) [![Greenkeeper badge](https://badges.greenkeeper.io/visjs/vis-network.svg)](https://greenkeeper.io/) [![npm](https://img.shields.io/npm/v/vis-network)](https://www.npmjs.com/package/vis-network)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
+[![Renovate](https://badges.renovateapi.com/github/visjs/vis-network)](https://app.renovatebot.com/)
+[![npm](https://img.shields.io/npm/v/vis-network)](https://www.npmjs.com/package/vis-network)
 
-[![GitHub contributors](https://img.shields.io/github/contributors/visjs/vis-network.svg)](https://github.com/visjs/vis-network/graphs/contributors) [![Backers on Open Collective](https://opencollective.com/visjs/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/visjs/sponsors/badge.svg)](#sponsors) 
+[![dependencies Status](https://david-dm.org/visjs/vis-network/status.svg)](https://david-dm.org/visjs/vis-network)
+[![devDependencies Status](https://david-dm.org/visjs/vis-network/dev-status.svg)](https://david-dm.org/visjs/vis-network?type=dev)
+[![peerDependencies Status](https://david-dm.org/visjs/vis-network/peer-status.svg)](https://david-dm.org/visjs/vis-network?type=peer)
+
+[![GitHub contributors](https://img.shields.io/github/contributors/visjs/vis-network.svg)](https://github.com/visjs/vis-network/graphs/contributors)
+[![Backers on Open Collective](https://opencollective.com/visjs/backers/badge.svg)](#backers)
+[![Sponsors on Open Collective](https://opencollective.com/visjs/sponsors/badge.svg)](#sponsors) 
 
 ## Install
 


### PR DESCRIPTION
We use Renovate for quite some time now. I also added a dependency state from https://david-dm.org/.