### PR TITLE
ci: increase timeouts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,11 @@ jobs:
             libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 \
             libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget \
             xdg-utils
-      - run: npm run generate-examples-index
+      - run:
+          command: npm run generate-examples-index
+          # One of the examples sports really massive network that takes long to
+          # render and would regularly exceed the default timeout of 10 minues.
+          no_output_timeout: 20m
 
       - persist_to_workspace:
           root: ..

--- a/cypress/support/access-globals.ts
+++ b/cypress/support/access-globals.ts
@@ -58,6 +58,11 @@ export function visStabilizeFitAndRunCode(
   callback: (props: RunCodeProps) => void
 ): void {
   cy.window().then(
+    {
+      // Stabilization can take really long time depenging on the CPU power
+      // available and the amount of nodes and edges used.
+      timeout: 30000
+    },
     async ({ edges, network, nodes }: any): Promise<void> => {
       if (edges && network && nodes) {
         /*


### PR DESCRIPTION
One of the examples renders massive network which often exceeds the default timeout even though it works as intended. Also the stabilization in E2E often exceeds its timeout.