### PR TITLE
New coordinateOrigin prop to change image/circularImage positioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ npm-debug.log
 .project
 .settings/
 .directory
+.vscode
 
 # temporary files
 .*.sw[op]

--- a/docs-kr/network/nodes.html
+++ b/docs-kr/network/nodes.html
@@ -205,7 +205,8 @@ var options = {
       borderRadius: 6,     // only for box shape
       interpolation: false,  // only for image and circularImage shapes
       useImageSize: false,  // only for image and circularImage shapes
-      useBorderWithImage: false  // only for image shape
+      useBorderWithImage: false,  // only for image shape
+      coordinateOrigin: 'center'  // only for image and circularImage shapes
     }
     size: 25,
     title: undefined,
@@ -1028,6 +1029,12 @@ mySize = minSize + diff * scale;
             <td><code>false</code></td>
             <td>이 속성은 <code> image </ code> 모양에만 적용됩니다. 참이면 색상 개체가 사용됩니다. 배경색이있는 사각형은 그것 뒤에 그려지며, 테두리를 가지게 됩니다. 이는 모든 테두리 옵션들이 고려되고 있음을 의미하고 있습니다.
             </td>
+        </tr>
+        <tr parent="shapeProperties" class="hidden">
+            <td class="indent">shapeProperties.coordinateOrigin</td>
+            <td>String</td>
+            <td><code>'center'</code></td>
+            <td>이 속성은 <code> image </ code> 및 <code> circularImage </ code> 모양에만 적용됩니다. Decides if the (x, y) of the node will be the <code>center</ code> of the image, or the <code>top-left</ code> corner.</td>
         </tr>
         <tr>
             <td>size</td>

--- a/docs/network/nodes.html
+++ b/docs/network/nodes.html
@@ -209,7 +209,8 @@ var options = {
       borderRadius: 6,     // only for box shape
       interpolation: false,  // only for image and circularImage shapes
       useImageSize: false,  // only for image and circularImage shapes
-      useBorderWithImage: false  // only for image shape
+      useBorderWithImage: false,  // only for image shape
+      coordinateOrigin: 'center'  // only for image and circularImage shapes
     }
     size: 25,
     title: undefined,
@@ -1069,6 +1070,15 @@ mySize = minSize + diff * scale;
             <td>This property only applies to the <code>image</code> shape.
                 When true, the color object is used. A rectangle with the background color is
                 drawn behind it and it has a border. This means all border options are taken into account.
+            </td>
+        </tr>
+        <tr parent="shapeProperties" class="hidden">
+            <td class="indent">shapeProperties.coordinateOrigin</td>
+            <td>String</td>
+            <td><code>'center'</code></td>
+            <td>This property only applies to the <code>image</code> and <code>circularImage</code> shapes.
+                Decides if the (x, y) of the node will be the <code>center</code> of the image,
+                or the <code>top-left</code> corner.
             </td>
         </tr>
         <tr>

--- a/examples/network/nodeStyles/imagesWithCoordinateOrigin.html
+++ b/examples/network/nodeStyles/imagesWithCoordinateOrigin.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html>
+<head>
+  <title>Vis Network | Node Styles | Images with alternative coordinate origin</title>
+
+  <style type="text/css">
+    #mynetwork {
+      width: 600px;
+      height: 600px;
+      border: 1px solid lightgray;
+    }
+  </style>
+
+  <script type="text/javascript" src="../../../standalone/umd/vis-network.min.js"></script>
+
+  <script type="text/javascript">
+    var nodes = null;
+    var edges = null;
+    var network = null;
+
+    var DIR = '../img/refresh-cl/';
+    var EDGE_LENGTH_MAIN = 150;
+    var EDGE_LENGTH_SUB = 50;
+
+    // Called when the Visualization API is loaded.
+    function draw() {
+      // Create a data table with nodes.
+      nodes = [];
+
+      // Create a data table with links.
+      edges = [];
+
+      nodes.push({id: 1, label: 'Main', image: DIR + 'Network-Pipe-icon.png', shape: 'image'});
+      nodes.push({id: 2, label: 'Office', image: DIR + 'Network-Pipe-icon.png', shape: 'image'});
+      nodes.push({id: 3, label: 'Wireless', image: DIR + 'Network-Pipe-icon.png', shape: 'image'});
+      edges.push({from: 1, to: 2, length: EDGE_LENGTH_MAIN});
+      edges.push({from: 1, to: 3, length: EDGE_LENGTH_MAIN});
+
+      for (var i = 4; i <= 7; i++) {
+        nodes.push({id: i, label: 'Computer (top-left)', image: DIR + 'Hardware-My-Computer-3-icon.png', shape: 'circularImage'});
+        edges.push({from: 2, to: i, length: EDGE_LENGTH_SUB});
+      }
+
+      nodes.push({id: 101, label: 'Printer', image: DIR + 'Hardware-Printer-Blue-icon.png', shape: 'circularImage'});
+      edges.push({from: 2, to: 101, length: EDGE_LENGTH_SUB});
+
+      nodes.push({
+        id: 102, 
+        label: 'Laptop (center)', 
+        image: DIR + 'Hardware-Laptop-1-icon.png', 
+        shape: 'circularImage',
+        shapeProperties: {
+            useImageSize: true,
+            useBorderWithImage: false,
+            interpolation: false,
+            coordinateOrigin: 'center'
+          }
+      });
+      edges.push({from: 3, to: 102, length: EDGE_LENGTH_SUB});
+
+      nodes.push({id: 103, label: 'network drive', image: DIR + 'Network-Drive-icon.png', shape: 'circularImage'});
+      edges.push({from: 1, to: 103, length: EDGE_LENGTH_SUB});
+
+      nodes.push({id: 104, label: 'Internet', image: DIR + 'System-Firewall-2-icon.png', shape: 'circularImage'});
+      edges.push({from: 1, to: 104, length: EDGE_LENGTH_SUB});
+
+      for (var i = 200; i <= 201; i++ ) {
+        nodes.push({
+          id: i, 
+          label: 'Smartphone (center)', 
+          image: DIR + 'Hardware-My-PDA-02-icon.png', 
+          shape: 'circularImage',
+          shapeProperties: {
+            useImageSize: true,
+            useBorderWithImage: false,
+            interpolation: false,
+            coordinateOrigin: 'center'
+          }
+        });
+        edges.push({from: 3, to: i, length: EDGE_LENGTH_SUB});
+      }
+
+      // create a network
+      var container = document.getElementById('mynetwork');
+      var data = {
+        nodes: nodes,
+        edges: edges
+      };
+      var options = {
+        nodes: {
+          size: 30,
+          shapeProperties: {
+            useImageSize: true,
+            useBorderWithImage: false,
+            interpolation: false,
+            coordinateOrigin: 'top-left'
+          }
+        }
+      };
+      network = new vis.Network(container, data, options);
+    }
+  </script>
+
+
+<body onload="draw()">
+
+<p>
+  Display nodes as images, but with the image drawn from the top-left coordinate.
+</p>
+<div id="mynetwork"></div>
+
+</body>
+</html>

--- a/examples/network/nodeStyles/imagesWithCoordinateOrigin.html
+++ b/examples/network/nodeStyles/imagesWithCoordinateOrigin.html
@@ -30,9 +30,9 @@
       // Create a data table with links.
       edges = [];
 
-      nodes.push({id: 1, label: 'Main', image: DIR + 'Network-Pipe-icon.png', shape: 'image'});
-      nodes.push({id: 2, label: 'Office', image: DIR + 'Network-Pipe-icon.png', shape: 'image'});
-      nodes.push({id: 3, label: 'Wireless', image: DIR + 'Network-Pipe-icon.png', shape: 'image'});
+      nodes.push({id: 1, label: 'Main (top-left)', image: DIR + 'Network-Pipe-icon.png', shape: 'image'});
+      nodes.push({id: 2, label: 'Office (top-left)', image: DIR + 'Network-Pipe-icon.png', shape: 'image'});
+      nodes.push({id: 3, label: 'Wireless (top-left)', image: DIR + 'Network-Pipe-icon.png', shape: 'image'});
       edges.push({from: 1, to: 2, length: EDGE_LENGTH_MAIN});
       edges.push({from: 1, to: 3, length: EDGE_LENGTH_MAIN});
 
@@ -41,7 +41,7 @@
         edges.push({from: 2, to: i, length: EDGE_LENGTH_SUB});
       }
 
-      nodes.push({id: 101, label: 'Printer', image: DIR + 'Hardware-Printer-Blue-icon.png', shape: 'circularImage'});
+      nodes.push({id: 101, label: 'Printer (top-left)', image: DIR + 'Hardware-Printer-Blue-icon.png', shape: 'circularImage'});
       edges.push({from: 2, to: 101, length: EDGE_LENGTH_SUB});
 
       nodes.push({
@@ -58,10 +58,10 @@
       });
       edges.push({from: 3, to: 102, length: EDGE_LENGTH_SUB});
 
-      nodes.push({id: 103, label: 'network drive', image: DIR + 'Network-Drive-icon.png', shape: 'circularImage'});
+      nodes.push({id: 103, label: 'Network drive (top-left)', image: DIR + 'Network-Drive-icon.png', shape: 'circularImage'});
       edges.push({from: 1, to: 103, length: EDGE_LENGTH_SUB});
 
-      nodes.push({id: 104, label: 'Internet', image: DIR + 'System-Firewall-2-icon.png', shape: 'circularImage'});
+      nodes.push({id: 104, label: 'Internet (top-left)', image: DIR + 'System-Firewall-2-icon.png', shape: 'circularImage'});
       edges.push({from: 1, to: 104, length: EDGE_LENGTH_SUB});
 
       for (var i = 200; i <= 201; i++ ) {

--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -133,7 +133,8 @@ class NodesHandler {
         borderRadius: 6,     // only for box shape
         interpolation: true,  // only for image and circularImage shapes
         useImageSize: false,  // only for image and circularImage shapes
-        useBorderWithImage: false  // only for image shape
+        useBorderWithImage: false,  // only for image shape
+        coordinateOrigin: 'center'  // only for image and circularImage shapes
       },
       size: 25,
       title: undefined,

--- a/lib/network/modules/components/Node.js
+++ b/lib/network/modules/components/Node.js
@@ -217,6 +217,15 @@ class Node {
     return 0 <= opacity && opacity <= 1;
   }
 
+  /**
+   * Check that origin is 'center' or 'top-left'
+   * 
+   * @param {String} origin 
+   * @returns {boolean}
+   */
+  static checkCoordinateOrigin (origin) {
+    return origin === undefined || origin === 'center' || origin === 'top-left'; 
+  }
 
   /**
    * Copy group option values into the node options.
@@ -300,6 +309,10 @@ class Node {
         console.error("Invalid option for node opacity. Value must be between 0 and 1, found: " + newOptions.opacity);
         newOptions.opacity = undefined;
       }
+    }
+
+    if(newOptions.shapeProperties && !Node.checkCoordinateOrigin(newOptions.shapeProperties.coordinateOrigin)){
+      console.error("Invalid option for node coordinateOrigin, found: " + newOptions.shapeProperties.coordinateOrigin);
     }
 
     // merge the shadow options into the parent.

--- a/lib/network/modules/components/nodes/shapes/CircularImage.js
+++ b/lib/network/modules/components/nodes/shapes/CircularImage.js
@@ -58,11 +58,22 @@ class CircularImage extends CircleImageBase {
   draw(ctx, x, y, selected, hover, values) {
     this.switchImages(selected);
     this.resize();
-    this.left = x - this.width / 2;
-    this.top = y - this.height / 2;
+
+    let labelX = x,
+      labelY = y;
+
+    if (this.options.shapeProperties.coordinateOrigin === 'top-left') {
+      this.left = x;
+      this.top = y;
+      labelX += this.width / 2;
+      labelY += this.height / 2;
+    } else {
+      this.left = x - this.width / 2;
+      this.top = y - this.height / 2;
+    }
 
     // draw the background circle. IMPORTANT: the stroke in this method is used by the clip method below.
-    this._drawRawCircle(ctx, x, y, values);
+    this._drawRawCircle(ctx, labelX, labelY, values);
 
     // now we draw in the circle, we save so we can revert the clip operation after drawing.
     ctx.save();
@@ -73,7 +84,7 @@ class CircularImage extends CircleImageBase {
     // restore so we can again draw on the full canvas
     ctx.restore();
 
-    this._drawImageLabel(ctx, x, y, selected, hover);
+    this._drawImageLabel(ctx, labelX, labelY, selected, hover);
 
     this.updateBoundingBox(x,y);
   }
@@ -85,10 +96,17 @@ class CircularImage extends CircleImageBase {
    * @param {number} y height
    */
   updateBoundingBox(x,y) {
-    this.boundingBox.top = y - this.options.size;
-    this.boundingBox.left = x - this.options.size;
-    this.boundingBox.right = x + this.options.size;
-    this.boundingBox.bottom = y + this.options.size;
+    if (this.options.shapeProperties.coordinateOrigin === 'top-left') {
+      this.boundingBox.top = y;
+      this.boundingBox.left = x;
+      this.boundingBox.right = x + this.options.size * 2;
+      this.boundingBox.bottom = y + this.options.size * 2;
+    } else {
+      this.boundingBox.top = y - this.options.size;
+      this.boundingBox.left = x - this.options.size;
+      this.boundingBox.right = x + this.options.size;
+      this.boundingBox.bottom = y + this.options.size;
+    }
 
     // TODO: compare with Image.updateBoundingBox(), consolidate?
     this.boundingBox.left = Math.min(this.boundingBox.left, this.labelModule.size.left);

--- a/lib/network/modules/components/nodes/shapes/Image.js
+++ b/lib/network/modules/components/nodes/shapes/Image.js
@@ -58,8 +58,19 @@ class Image extends CircleImageBase {
     ctx.save();
     this.switchImages(selected);
     this.resize();
-    this.left = x - this.width / 2;
-    this.top = y - this.height / 2;
+
+    let labelX = x,
+      labelY = y;
+
+    if (this.options.shapeProperties.coordinateOrigin === 'top-left') {
+      this.left = x;
+      this.top = y;
+      labelX += this.width / 2;
+      labelY += this.height / 2;
+    } else {
+      this.left = x - this.width / 2;
+      this.top = y - this.height / 2;
+    }
 
     if (this.options.shapeProperties.useBorderWithImage === true) {
       var neutralborderWidth = this.options.borderWidth;
@@ -95,7 +106,7 @@ class Image extends CircleImageBase {
 
     this._drawImageAtPosition(ctx, values);
 
-    this._drawImageLabel(ctx, x, y, selected, hover);
+    this._drawImageLabel(ctx, labelX, labelY, selected, hover);
 
     this.updateBoundingBox(x,y);
     ctx.restore();
@@ -108,7 +119,19 @@ class Image extends CircleImageBase {
    */
   updateBoundingBox(x, y) {
     this.resize();
-    this._updateBoundingBox(x, y);
+
+    if (this.options.shapeProperties.coordinateOrigin === 'top-left') {
+      this.left = x;
+      this.top = y;
+    } else {
+      this.left = x - this.width / 2;
+      this.top = y - this.height / 2;
+    }
+
+    this.boundingBox.left = this.left;
+    this.boundingBox.top = this.top;
+    this.boundingBox.bottom = this.top + this.height;
+    this.boundingBox.right = this.left + this.width;
 
     if (this.options.label !== undefined && this.labelModule.size.width > 0) {
       this.boundingBox.left = Math.min(this.boundingBox.left, this.labelModule.size.left);

--- a/lib/network/options.js
+++ b/lib/network/options.js
@@ -403,6 +403,7 @@ let allOptions = {
       interpolation: { boolean: bool },
       useImageSize: { boolean: bool },
       useBorderWithImage: { boolean: bool },
+      coordinateOrigin: { string: ['center', 'top-left'] },
       __type__: { object }
     },
     size: { number },

--- a/types/network/Network.d.ts
+++ b/types/network/Network.d.ts
@@ -910,7 +910,8 @@ export interface NodeOptions {
     borderRadius?: number,     // only for box shape
     interpolation?: boolean,  // only for image and circularImage shapes
     useImageSize?: boolean,  // only for image and circularImage shapes
-    useBorderWithImage?: boolean  // only for image shape
+    useBorderWithImage?: boolean,  // only for image shape
+    coordinateOrigin?: string  // only for image and circularImage shapes
   };
 
   size?: number;


### PR DESCRIPTION
This PR allows the use of (x, y) of the node as the (0, 0) position of the image instead of using width/2 and height/2.

A new shape property was added: coordinateOrigin (default 'center'). The new option `top-left` allows the image/circle image's top-left corner to be the x,y position of the node

Closes https://github.com/visjs/vis-network/issues/811
Closes https://github.com/visjs/vis-network/pull/812
