### PR TITLE
style: prohibit trailing spaces

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
   // For the full list of rules, see: http://eslint.org/docs/rules/
   rules: {
     'prettier/prettier': ['off'],
+    'no-trailing-spaces': 'error',
 
     complexity: ['error', 55],
     "max-statements": ['error', 115],

--- a/examples/network/exampleApplications/disassemblerExample.js
+++ b/examples/network/exampleApplications/disassemblerExample.js
@@ -32,7 +32,7 @@ const nodes = [
 
 //
 // Note: there are a couple of node id's present here which do not exist
-// - cfg_0x00417563 
+// - cfg_0x00417563
 // - cfg_0x00403489
 // - cfg_0x0042f03f
 //

--- a/lib/network/CachedImage.js
+++ b/lib/network/CachedImage.js
@@ -13,7 +13,7 @@
 class CachedImage {
   /**
    * @ignore
-   */  
+   */
   constructor() {  // eslint-disable-line no-unused-vars
     this.NUM_ITERATIONS = 4;  // Number of items in the coordinates array
 

--- a/lib/network/Images.js
+++ b/lib/network/Images.js
@@ -20,12 +20,12 @@ class Images {
         this.imageBroken = {};
         this.callback = callback;
     }
-    
+
     /**
      * @param {string} url                      The original Url that failed to load, if the broken image is successfully loaded it will be added to the cache using this Url as the key so that subsequent requests for this Url will return the broken image
      * @param {string} brokenUrl                Url the broken image to try and load
      * @param {Image} imageToLoadBrokenUrlOn   The image object
-     */    
+     */
     _tryloadBrokenUrl (url, brokenUrl, imageToLoadBrokenUrlOn) {
         //If these parameters aren't specified then exit the function because nothing constructive can be done
         if (url === undefined || imageToLoadBrokenUrlOn === undefined)  return;
@@ -33,17 +33,17 @@ class Images {
           console.warn("No broken url image defined");
           return;
         }
-    
+
         //Clear the old subscription to the error event and put a new in place that only handle errors in loading the brokenImageUrl
         imageToLoadBrokenUrlOn.image.onerror = () => {
             console.error("Could not load brokenImage:", brokenUrl);
             // cache item will contain empty image, this should be OK for default
         };
-        
+
         //Set the source of the image to the brokenUrl, this is actually what kicks off the loading of the broken image
         imageToLoadBrokenUrlOn.image.src = brokenUrl;
     }
-    
+
   /**
    *
    * @param {vis.Image} imageToRedrawWith
@@ -54,42 +54,42 @@ class Images {
             this.callback(imageToRedrawWith);
         }
     }
-    
+
     /**
      * @param {string} url          Url of the image
      * @param {string} brokenUrl    Url of an image to use if the url image is not found
      * @return {Image} img          The image object
-     */     
+     */
     load (url, brokenUrl) {
-        //Try and get the image from the cache, if successful then return the cached image   
-        const cachedImage = this.images[url]; 
+        //Try and get the image from the cache, if successful then return the cached image
+        const cachedImage = this.images[url];
         if (cachedImage) return cachedImage;
-        
+
         //Create a new image
         const img = new CachedImage();
 
         // Need to add to cache here, otherwise final return will spawn different copies of the same image,
         // Also, there will be multiple loads of the same image.
-        this.images[url] = img; 
-        
-        //Subscribe to the event that is raised if the image loads successfully 
+        this.images[url] = img;
+
+        //Subscribe to the event that is raised if the image loads successfully
         img.image.onload = () => {
             // Properly init the cached item and then request a redraw
             this._fixImageCoordinates(img.image);
             img.init();
             this._redrawWithImage(img);
         };
-        
+
         //Subscribe to the event that is raised if the image fails to load
         img.image.onerror = () => {
             console.error("Could not load image:", url);
             //Try and load the image specified by the brokenUrl using
             this._tryloadBrokenUrl(url, brokenUrl, img);
         };
-        
+
         //Set the source of the image to the url, this is what actually kicks off the loading of the image
         img.image.src = url;
-        
+
         //Return the new image
         return img;
     }

--- a/lib/network/dotparser.js
+++ b/lib/network/dotparser.js
@@ -21,8 +21,8 @@
  * ====
  *
  * For label handling, this is an incomplete implementation. From docs (quote #3015):
- * 
- * > the escape sequences "\n", "\l" and "\r" divide the label into lines, centered, 
+ *
+ * > the escape sequences "\n", "\l" and "\r" divide the label into lines, centered,
  * > left-justified, and right-justified, respectively.
  *
  * Source: http://www.graphviz.org/content/attrs#kescString

--- a/lib/network/modules/CanvasRenderer.js
+++ b/lib/network/modules/CanvasRenderer.js
@@ -86,10 +86,10 @@ class CanvasRenderer {
     this.body.emitter.on("zoom", () => {
       this.zooming = true;
       window.clearTimeout(this.zoomTimeoutId)
-      this.zoomTimeoutId = window.setTimeout(() => { 
+      this.zoomTimeoutId = window.setTimeout(() => {
         this.zooming = false;
         this._requestRedraw.bind(this)()
-      }, 250) 
+      }, 250)
     });
     this.body.emitter.on("_resizeNodes", () => { this._resizeNodes(); });
     this.body.emitter.on("_redraw", () => {
@@ -148,7 +148,7 @@ class CanvasRenderer {
    * @returns {function|undefined}
    * @private
    */
-  _requestNextFrame(callback, delay) { 
+  _requestNextFrame(callback, delay) {
     // During unit testing, it happens that the mock window object is reset while
     // the next frame is still pending. Then, either 'window' is not present, or
     // 'requestAnimationFrame()' is not present because it is not defined on the
@@ -276,7 +276,7 @@ class CanvasRenderer {
 
       if (hidden === false) {
         if (
-          (this.dragging === false || (this.dragging === true && this.options.hideEdgesOnDrag === false)) && 
+          (this.dragging === false || (this.dragging === true && this.options.hideEdgesOnDrag === false)) &&
           (this.zooming === false || (this.zooming === true && this.options.hideEdgesOnZoom === false))
         ) {
           this._drawEdges(ctx);
@@ -290,7 +290,7 @@ class CanvasRenderer {
       // draw the arrows last so they will be at the top
       if (hidden === false) {
         if (
-          (this.dragging === false || (this.dragging === true && this.options.hideEdgesOnDrag === false)) && 
+          (this.dragging === false || (this.dragging === true && this.options.hideEdgesOnDrag === false)) &&
           (this.zooming === false || (this.zooming === true && this.options.hideEdgesOnZoom === false))
         ) {
           this._drawArrows(ctx);

--- a/lib/network/modules/Clustering.js
+++ b/lib/network/modules/Clustering.js
@@ -50,7 +50,7 @@ Member `network.clustering` contains the following items:
 Due to nesting of clusters, these members can contain cluster nodes and edges as well.
 
 The important thing to note here, is that the clustered nodes and edges also
-appear in the members of the cluster nodes. For data update, it is therefore 
+appear in the members of the cluster nodes. For data update, it is therefore
 important to scan these lists as well as the cluster nodes.
 
 
@@ -61,7 +61,7 @@ A cluster node has the following extra fields:
 - `isCluster : true` - indication that this is a cluster node
 - `containedNodes`   - hash of nodes contained in this cluster
 - `containedEdges`   - same for edges
-- `edges`            - array of cluster edges for this node 
+- `edges`            - array of cluster edges for this node
 
 
 **NOTE:**
@@ -729,7 +729,7 @@ class ClusterEngine {
       return;
     }
 
-    // main body 
+    // main body
     const containedNodes = clusterNode.containedNodes;
     const containedEdges = clusterNode.containedEdges;
 
@@ -794,7 +794,7 @@ class ClusterEngine {
       for (let j = 0; j < edge.clusteringEdgeReplacingIds.length; j++) {
         const transferId = edge.clusteringEdgeReplacingIds[j];
         const transferEdge = this.body.edges[transferId];
-        if (transferEdge === undefined) continue; 
+        if (transferEdge === undefined) continue;
 
         // if the other node is in another cluster, we transfer ownership of this edge to the other cluster
         if (otherNode !== undefined) {
@@ -1276,7 +1276,7 @@ class ClusterEngine {
       }
     });
 
-    // Cluster nodes can also contain edges which are not clustered, 
+    // Cluster nodes can also contain edges which are not clustered,
     // i.e. nodes 1-2 within cluster with an edge in between.
     // So the cluster nodes also need to be scanned for invalid edges
     eachClusterNode(function(clusterNode) {
@@ -1380,7 +1380,7 @@ class ClusterEngine {
         this._restoreEdge(edge);
         // This should not be happening, the state should
         // be properly updated at this point.
-        // 
+        //
         // If it *is* reached during normal operation, then we have to implement
         // undo clustering for this edge here.
         // throw new Error('remove edge from clustering not implemented!')

--- a/lib/network/modules/EdgesHandler.js
+++ b/lib/network/modules/EdgesHandler.js
@@ -33,7 +33,7 @@ class EdgesHandler {
         from:   {enabled: false, scaleFactor:1, type: 'arrow'}
       },
       endPointOffset: {
-        from: 0, 
+        from: 0,
         to: 0
       },
       arrowStrikethrough: true,
@@ -98,7 +98,7 @@ class EdgesHandler {
         }
       },
       selectionWidth: 1.5,
-      selfReference: { 
+      selfReference: {
         size: 20,
         angle: Math.PI / 4,
         renderBehindTheNode: true
@@ -454,7 +454,7 @@ class EdgesHandler {
    * @private
    */
   _removeInvalidEdges() {
-    
+
     const edgesToDelete = [];
 
     forEach(this.body.edges, (edge, id) => {
@@ -478,11 +478,11 @@ class EdgesHandler {
   /**
    * add all edges from dataset that are not in the cached state
    * @private
-   */ 
+   */
   _addMissingEdges() {
      const edgesData = this.body.data.edges;
      if (edgesData === undefined || edgesData === null) {
-       return;  // No edges DataSet yet; can happen on startup 
+       return;  // No edges DataSet yet; can happen on startup
      }
 
      const edges = this.body.edges;
@@ -494,9 +494,9 @@ class EdgesHandler {
            addIds.push(edgeId);
          }
      });
-     
+
      this.add(addIds,true);
-   }  
+   }
 }
 
 export default EdgesHandler;

--- a/lib/network/modules/Groups.js
+++ b/lib/network/modules/Groups.js
@@ -63,7 +63,7 @@ class Groups {
     }
   }
 
-  
+
   /**
    * Clear all groups
    */
@@ -71,7 +71,7 @@ class Groups {
     this.groups = {};
     this.groupsArray = [];
   }
-  
+
   /**
    * Get group options of a groupname.
    * If groupname is not found, a new group may be created.
@@ -101,10 +101,10 @@ class Groups {
         this.groups[groupname] = group;
       }
     }
-  
+
     return group;
   }
-  
+
   /**
    * Add a custom group style
    * @param {string} groupName

--- a/lib/network/modules/InteractionHandler.js
+++ b/lib/network/modules/InteractionHandler.js
@@ -311,7 +311,7 @@ class InteractionHandler {
     this.drag.selection = [];
     this.drag.translation = Object.assign({},this.body.view.translation); // copy the object
     this.drag.nodeId = undefined;
-    
+
     if (event.srcEvent.shiftKey) {
       this.body.selectionBox.show = true;
       const pointer = this.getPointer(event.center);
@@ -404,7 +404,7 @@ class InteractionHandler {
       // create selection box
       if (event.srcEvent.shiftKey) {
         this.selectionHandler._generateClickEvent('dragging', event, pointer, undefined, true);
-  
+
         // if the drag was not started properly because the click started outside the network div, start it now.
         if (this.drag.pointer === undefined) {
           this.onDragStart(event);
@@ -414,11 +414,11 @@ class InteractionHandler {
         this.body.selectionBox.position.end =  { x: this.canvas._XconvertDOMtoCanvas(pointer.x), y: this.canvas._YconvertDOMtoCanvas(pointer.y) };
         this.body.emitter.emit('_requestRedraw');
       }
-      
+
       // move the network
       if (this.options.dragView === true && !event.srcEvent.shiftKey) {
         this.selectionHandler._generateClickEvent('dragging', event, pointer, undefined, true);
-  
+
         // if the drag was not started properly because the click started outside the network div, start it now.
         if (this.drag.pointer === undefined) {
           this.onDragStart(event);
@@ -442,10 +442,10 @@ class InteractionHandler {
    */
   onDragEnd(event) {
     this.drag.dragging = false;
-    
+
     if (this.body.selectionBox.show) {
       this.body.selectionBox.show = false;
-      const selectionBoxPosition = this.body.selectionBox.position 
+      const selectionBoxPosition = this.body.selectionBox.position
       const selectionBoxPositionMinMax = {
         minX: Math.min(selectionBoxPosition.start.x, selectionBoxPosition.end.x),
         minY: Math.min(selectionBoxPosition.start.y, selectionBoxPosition.end.y),
@@ -457,7 +457,7 @@ class InteractionHandler {
         const node = this.body.nodes[nodeId];
         return (
           node.x >= selectionBoxPositionMinMax.minX && node.x <= selectionBoxPositionMinMax.maxX &&
-          node.y >= selectionBoxPositionMinMax.minY && node.y <= selectionBoxPositionMinMax.maxY 
+          node.y >= selectionBoxPositionMinMax.minY && node.y <= selectionBoxPositionMinMax.maxY
         )
         });
 

--- a/lib/network/modules/LayoutEngine.js
+++ b/lib/network/modules/LayoutEngine.js
@@ -64,7 +64,7 @@ class HierarchicalStatus {
     this.levels = {};                // hierarchy level per node id
     this.distributionIndex = {};     // The position of the node in the level sorting order, per node id.
 
-    this.isTree = false;             // True if current network is a formal tree 
+    this.isTree = false;             // True if current network is a formal tree
     this.treeIndex = -1;             // Highest tree id in current network.
   }
 
@@ -1410,7 +1410,7 @@ class LayoutEngine {
   _getActiveEdges(node) {
     const result = [];
 
-    forEach(node.edges, (edge) => { 
+    forEach(node.edges, (edge) => {
       if (this.body.edgeIndices.indexOf(edge.id) !== -1) {
         result.push(edge);
       }
@@ -1430,7 +1430,7 @@ class LayoutEngine {
     const hubSizes = {};
     const nodeIds = this.body.nodeIndices;
 
-    forEach(nodeIds, (nodeId) => { 
+    forEach(nodeIds, (nodeId) => {
       const node = this.body.nodes[nodeId];
       const hubSize = this._getActiveEdges(node).length;
       hubSizes[hubSize] = true;
@@ -1438,7 +1438,7 @@ class LayoutEngine {
 
     // Make an array of the size sorted descending
     const result = [];
-    forEach(hubSizes, (size) => { 
+    forEach(hubSizes, (size) => {
       result.push(Number(size));
     });
 
@@ -1466,7 +1466,7 @@ class LayoutEngine {
       const hubSize = hubSizes[i];
       if (hubSize === 0) break;
 
-      forEach(this.body.nodeIndices, (nodeId) => { 
+      forEach(this.body.nodeIndices, (nodeId) => {
         const node = this.body.nodes[nodeId];
 
         if (hubSize === this._getActiveEdges(node).length) {
@@ -1694,9 +1694,9 @@ class LayoutEngine {
                    || this.options.hierarchical.direction === 'DU');
 
     if(isVertical) {
-      this.direction = new VerticalStrategy(this); 
+      this.direction = new VerticalStrategy(this);
     } else {
-      this.direction = new HorizontalStrategy(this); 
+      this.direction = new HorizontalStrategy(this);
     }
   }
 

--- a/lib/network/modules/ManipulationSystem.js
+++ b/lib/network/modules/ManipulationSystem.js
@@ -1020,7 +1020,7 @@ class ManipulationSystem {
 
       this.interactionHandler.drag.pointer = this.lastTouch; // Drag pointer is not updated when adding edges
       this.interactionHandler.drag.translation = this.lastTouch.translation;
-      
+
       const pointer = this.lastTouch;
       const node = this.selectionHandler.getNodeAt(pointer);
 
@@ -1082,7 +1082,7 @@ class ManipulationSystem {
         break;
       }
     }
-    
+
     event.controlEdge = { from: connectFromId, to: node ? node.id : undefined };
     this.selectionHandler._generateClickEvent('controlNodeDragging', event, pointer);
 

--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -180,7 +180,7 @@ class NodesHandler {
   setOptions(options) {
     if (options !== undefined) {
       Node.parseOptions(this.options, options);
-      
+
       // Need to set opacity here because Node.parseOptions is also used for groups,
       // if you set opacity in Node.parseOptions it overwrites group opacity.
       if (options.opacity !== undefined) {
@@ -427,7 +427,7 @@ class NodesHandler {
     }
     return dataArray;
   }
-  
+
   /**
    * Retrieves the x y position of a specific id.
    *

--- a/lib/network/modules/View.js
+++ b/lib/network/modules/View.js
@@ -115,7 +115,7 @@ class View {
     const animationOptions = {position: center, scale: zoomLevel, animation: options.animation};
     this.moveTo(animationOptions);
   }
-  
+
   // animation
 
   /**

--- a/lib/network/modules/components/DirectionStrategy.js
+++ b/lib/network/modules/components/DirectionStrategy.js
@@ -113,7 +113,7 @@ class DirectionInterface {
 
 
   /**
-   * Add an offset to the unfixed coordinate of the given node. 
+   * Add an offset to the unfixed coordinate of the given node.
    *
    * @param {NodeId} nodeId Id of the node to adjust
    * @param {number} diff Offset to add to the unfixed coordinate

--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -166,7 +166,7 @@ class Edge {
     }
 
     if (newOptions.endPointOffset !== undefined && newOptions.endPointOffset.to !== undefined) {
-      if (Number.isFinite(newOptions.endPointOffset.to)) { 
+      if (Number.isFinite(newOptions.endPointOffset.to)) {
         parentOptions.endPointOffset.to = newOptions.endPointOffset.to;
       } else {
         parentOptions.endPointOffset.to = globalOptions.endPointOffset.to !== undefined ? globalOptions.endPointOffset.to : 0;
@@ -286,7 +286,7 @@ class Edge {
       console.log('The selfReferenceSize property has been deprecated. Please use selfReference property instead. The selfReference can be set like thise selfReference:{size:30, angle:Math.PI / 4}');
       parentOptions.selfReference.size = newOptions.selfReferenceSize
     }
-  
+
   }
 
 
@@ -576,7 +576,7 @@ class Edge {
 
     // get the via node from the edge type
     const viaNode = this.edgeType.getViaNode();
-    
+
     // draw line and label
     this.edgeType.drawLine(ctx, values, this.selected, this.hover, viaNode);
     this.drawLabel(ctx, viaNode);
@@ -667,7 +667,7 @@ class Edge {
         arrowData.middle.imageHeight = values.middleArrowImageHeight;
       }
     }
-    
+
     if (values.fromArrow) {
       this.edgeType.drawArrowHead(ctx, values, this.selected, this.hover, arrowData.from);
     }
@@ -677,7 +677,7 @@ class Edge {
     if (values.toArrow) {
       this.edgeType.drawArrowHead(ctx, values, this.selected, this.hover, arrowData.to);
     }
-    
+
   }
 
   /**
@@ -739,7 +739,7 @@ class Edge {
           this.options.selfReference.size,
           this.options.selfReference.angle
         );
-        
+
         this.labelModule.draw(ctx, point.x, point.y, this.selected, this.hover);
       }
     }
@@ -801,7 +801,7 @@ class Edge {
   }
 
 
-  /** 
+  /**
    * Determine the rotation point, if any.
    *
    * @param {CanvasRenderingContext2D} [ctx] if passed, do a recalculation of the label size
@@ -849,7 +849,7 @@ class Edge {
    * @param {number} x
    * @param {number} y
    * @param {number} radius
-   * @param {number} angle 
+   * @param {number} angle
    * @return {Object} point
    * @private
    */

--- a/lib/network/modules/components/Node.js
+++ b/lib/network/modules/components/Node.js
@@ -111,7 +111,7 @@ class Node {
    */
   setOptions(options) {
     const currentShape = this.options.shape;
-    
+
     if (!options) {
       return;  // Note that the return value will be 'undefined'! This is OK.
     }
@@ -148,11 +148,11 @@ class Node {
 
     // this transforms all shorthands into fully defined options
     Node.parseOptions(this.options, options, true, this.globalOptions, this.grouplist);
-    
+
     const pile = [options, this.options, this.defaultOptions];
     this.chooser = choosify('node', pile);
 
-    
+
 
     this._load_images();
     this.updateLabelModule(options);
@@ -207,11 +207,11 @@ class Node {
       }
     }
   }
-  
+
   /**
    * Check that opacity is only between 0 and 1
-   * 
-   * @param {Number} opacity 
+   *
+   * @param {Number} opacity
    * @returns {boolean}
    */
   static checkOpacity (opacity) {
@@ -220,12 +220,12 @@ class Node {
 
   /**
    * Check that origin is 'center' or 'top-left'
-   * 
-   * @param {String} origin 
+   *
+   * @param {String} origin
    * @returns {boolean}
    */
   static checkCoordinateOrigin (origin) {
-    return origin === undefined || origin === 'center' || origin === 'top-left'; 
+    return origin === undefined || origin === 'center' || origin === 'top-left';
   }
 
   /**
@@ -250,11 +250,11 @@ class Node {
       throw new Error("updateGroupOptions: group values in options don't match.");
     }
 
-    
+
     const hasGroup = (typeof group === 'number' || (typeof group === 'string' && group != ''));
     if (!hasGroup) return;  // current node has no group, no need to merge
-    
-    
+
+
     const groupObj = groupList.get(group);
 
     if (groupObj.opacity !== undefined && newOptions.opacity === undefined) {
@@ -297,7 +297,7 @@ class Node {
 
     Node.checkMass(newOptions);
 
-    
+
     if (parentOptions.opacity !== undefined) {
       if (!Node.checkOpacity(parentOptions.opacity)) {
         console.error("Invalid option for node opacity. Value must be between 0 and 1, found: " + parentOptions.opacity);

--- a/lib/network/modules/components/nodes/shapes/Image.js
+++ b/lib/network/modules/components/nodes/shapes/Image.js
@@ -100,7 +100,7 @@ class Image extends CircleImageBase {
       ctx.fill();
 
      this.performStroke(ctx, values);
- 
+
       ctx.closePath();
     }
 

--- a/lib/network/modules/components/nodes/util/CircleImageBase.js
+++ b/lib/network/modules/components/nodes/util/CircleImageBase.js
@@ -47,7 +47,7 @@ class CircleImageBase extends NodeBase {
    * Set the images for this node.
    *
    * The images can be updated after the initial setting of options;
-   * therefore, this method needs to be reentrant. 
+   * therefore, this method needs to be reentrant.
    *
    * For correct working in error cases, it is necessary to properly set
    * field 'nodes.brokenImage' in the options.
@@ -91,7 +91,7 @@ class CircleImageBase extends NodeBase {
    */
   _getImagePadding() {
     const imgPadding = { top: 0, right: 0, bottom: 0, left: 0}
-      if (this.options.imagePadding) {          
+      if (this.options.imagePadding) {
         const optImgPadding = this.options.imagePadding
         if (typeof optImgPadding == 'object') {
           imgPadding.top = optImgPadding.top;
@@ -106,7 +106,7 @@ class CircleImageBase extends NodeBase {
         }
       }
 
-      return imgPadding  
+      return imgPadding
   }
 
   /**
@@ -131,7 +131,7 @@ class CircleImageBase extends NodeBase {
           ratio_height = this.imageObj.height / this.imageObj.width;
         }
       }
-	  
+
 	  width = this.options.size * 2 * ratio_width;
       height = this.options.size * 2 * ratio_height;
     }

--- a/lib/network/modules/components/nodes/util/NodeBase.js
+++ b/lib/network/modules/components/nodes/util/NodeBase.js
@@ -204,7 +204,7 @@ class NodeBase {
     ctx.fill();
     // disable shadows for other elements.
     this.disableShadow(ctx, values);
-    
+
     ctx.restore();
     this.performStroke(ctx, values);
   }

--- a/lib/network/modules/components/nodes/util/ShapeBase.js
+++ b/lib/network/modules/components/nodes/util/ShapeBase.js
@@ -61,7 +61,7 @@ class ShapeBase extends NodeBase {
       getShape(shape)(ctx, x, y, values.size);
       this.performFill(ctx, values);
     }
-    
+
     if (this.options.icon !== undefined) {
       if (this.options.icon.code !== undefined) {
         ctx.font = (selected ? "bold " : "")

--- a/lib/network/modules/components/shared/ComponentUtil.js
+++ b/lib/network/modules/components/shared/ComponentUtil.js
@@ -23,7 +23,7 @@ import { topMost } from 'vis-util/esnext';
    *
    * @param {string}  subOption  option within object 'chosen' to consider; either 'node', 'edge' or 'label'
    * @param {Object}  pile       array of options objects to consider
-   * 
+   *
    * @return {boolean|function}  value for passed subOption of 'chosen' to use
    */
   export function choosify(subOption, pile) {
@@ -71,7 +71,7 @@ import { topMost } from 'vis-util/esnext';
       };
 
       if (rotationPoint.angle !== 0) {
-        // In order to get the coordinates the same, you need to 
+        // In order to get the coordinates the same, you need to
         // rotate in the reverse direction
         const angle = -rotationPoint.angle;
 
@@ -117,19 +117,19 @@ import { topMost } from 'vis-util/esnext';
    * Returns x, y of self reference circle based on provided angle
    *
    * @param {Object} ctx
-   * @param {number} angle 
-   * @param {number} radius 
-   * @param {VisNode} node 
+   * @param {number} angle
+   * @param {number} radius
+   * @param {VisNode} node
    *
    * @returns {Object} x and y coordinates
    */
   export function getSelfRefCoordinates(ctx, angle, radius, node){
     let x = node.x;
     let y = node.y;
-    
+
     if(typeof node.distanceToBorder === "function"){
         //calculating opposite and adjacent
-        //distaneToBorder becomes Hypotenuse. 
+        //distaneToBorder becomes Hypotenuse.
         //Formulas sin(a) = Opposite / Hypotenuse and cos(a) = Adjacent / Hypotenuse
         const toBorderDist = node.distanceToBorder(ctx, angle);
         const yFromNodeCenter = Math.sin(angle)*toBorderDist;
@@ -148,7 +148,7 @@ import { topMost } from 'vis-util/esnext';
           x += xFromNodeCenter;
           y -= yFromNodeCenter;
         }
-      
+
 
     } else if (node.shape.width > node.shape.height) {
       x = node.x + node.shape.width * 0.5;
@@ -157,6 +157,6 @@ import { topMost } from 'vis-util/esnext';
       x = node.x + radius;
       y = node.y - node.shape.height * 0.5;
     }
-    
+
     return {x,y};
   }

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -40,7 +40,7 @@ class Label {
    * @param {Object} options the options of the parent Node-instance
    */
   setOptions(options) {
-    this.elementOptions = options;  // Reference to the options of the parent Node-instance 
+    this.elementOptions = options;  // Reference to the options of the parent Node-instance
 
     this.initFontOptions(options.font);
 
@@ -57,7 +57,7 @@ class Label {
       }
       else if (typeof options.font === 'object') {
         const size = options.font.size;
- 
+
         if (size !== undefined) {
           this.baseSize = size;
         }
@@ -218,7 +218,7 @@ class Label {
   /**
    * Add the font members of the passed list of option objects to the pile.
    *
-   * @param {Pile} dstPile  pile of option objects add to 
+   * @param {Pile} dstPile  pile of option objects add to
    * @param {Pile} srcPile  pile of option objects to take font options from
    * @private
    */
@@ -267,7 +267,7 @@ class Label {
       }
 
       forEach(fontOptions, (opt, name) => {
-        if (opt === undefined) return;        // multi-font option need not be present 
+        if (opt === undefined) return;        // multi-font option need not be present
         if (Object.prototype.hasOwnProperty.call(ret, name)) return; // Keep first value we encounter
 
         if (multiFontStyle.indexOf(name) !== -1) {
@@ -455,7 +455,7 @@ class Label {
    * @param {number} x
    * @param {number} y
    * @param {string} [baseline='middle']
-   * @param {number} viewFontSize 
+   * @param {number} viewFontSize
    * @private
    */
   _drawText(ctx, x, y, baseline = 'middle', viewFontSize) {
@@ -654,7 +654,7 @@ class Label {
         return fontOptions[option];
       }
 
-      if (fontOptions[mod][option] !== undefined) {  // Grumbl leaving out test on undefined equals false for "" 
+      if (fontOptions[mod][option] !== undefined) {  // Grumbl leaving out test on undefined equals false for ""
         return fontOptions[mod][option];
       } else {
         // Take from parent font option
@@ -703,7 +703,7 @@ class Label {
   differentState(selected, hover) {
     return ((selected !== this.selectedState) || (hover !== this.hoverState));
   }
-   
+
 
   /**
    * This explodes the passed text into lines and determines the width, height and number of lines.
@@ -732,7 +732,7 @@ class Label {
 
     if(this.labelDirty === false && !this.differentState(selected,hover))
       return;
-    
+
     const state = this._processLabelText(ctx, selected, hover, this.elementOptions.label);
 
     if ((this.fontOptions.minWdt > 0) && (state.width < this.fontOptions.minWdt)) {

--- a/lib/network/modules/components/shared/LabelAccumulator.js
+++ b/lib/network/modules/components/shared/LabelAccumulator.js
@@ -34,7 +34,7 @@ class LabelAccumulator {
    * @param {'bold'|'ital'|'boldital'|'mono'|'normal'} [mod='normal']
    * @private
    */
-  _add(l, text, mod = 'normal') { 
+  _add(l, text, mod = 'normal') {
 
     if (this.lines[l] === undefined) {
       this.lines[l] = {
@@ -90,7 +90,7 @@ class LabelAccumulator {
     * @param {string} text
     * @param {'bold'|'ital'|'boldital'|'mono'|'normal'} [mod='normal']
     */
-   append(text, mod = 'normal') { 
+   append(text, mod = 'normal') {
      this._add(this.current, text, mod);
    }
 
@@ -111,7 +111,7 @@ class LabelAccumulator {
    * Determine and set the heights of all the lines currently contained in this instance
    *
    * Note that width has already been set.
-   * 
+   *
    * @private
    */
   determineLineHeights() {
@@ -130,7 +130,7 @@ class LabelAccumulator {
           }
         }
       }
-  
+
       line.height = height;
     }
   }
@@ -138,7 +138,7 @@ class LabelAccumulator {
 
   /**
    * Determine the full size of the label text, as determined by current lines and blocks
-   * 
+   *
    * @private
    */
   determineLabelSize() {
@@ -160,7 +160,7 @@ class LabelAccumulator {
 
   /**
    * Remove all empty blocks and empty lines we don't need
-   * 
+   *
    * This must be done after the width/height determination,
    * so that these are set properly for processing here.
    *
@@ -232,7 +232,7 @@ class LabelAccumulator {
       lines : tmpLines
     }
   }
-} 
+}
 
 
 export default LabelAccumulator;

--- a/lib/network/modules/components/shared/LabelSplitter.js
+++ b/lib/network/modules/components/shared/LabelSplitter.js
@@ -50,7 +50,7 @@ class MarkupAccumulator {
   /**
    * Return the mod label currently on the top of the stack
    *
-   * @returns {string}  label of topmost mod 
+   * @returns {string}  label of topmost mod
    * @private
    */
   mod() {
@@ -60,8 +60,8 @@ class MarkupAccumulator {
 
   /**
    * Return the mod label currently active
-   * 
-   * @returns {string}  label of active mod 
+   *
+   * @returns {string}  label of active mod
    * @private
    */
   modName() {
@@ -195,7 +195,7 @@ class MarkupAccumulator {
   /**
    * @param {string} tagName label for block type we are currently processing
    * @param {string|RegExp} tag string to match in text
-   * @param {RegExp} [nextTag] regular expression to match for characters *following* the current tag 
+   * @param {RegExp} [nextTag] regular expression to match for characters *following* the current tag
    * @returns {boolean} true if the tag was processed, false otherwise
    */
   parseEndTag(tagName, tag, nextTag) {
@@ -284,7 +284,7 @@ class LabelSplitter {
   /**
    * @param {CanvasRenderingContext2D} ctx Canvas rendering context
    * @param {Label} parent reference to the Label instance using current instance
-   * @param {boolean} selected 
+   * @param {boolean} selected
    * @param {boolean} hover
    */
   constructor(ctx, parent, selected, hover) {
@@ -333,7 +333,7 @@ class LabelSplitter {
    *
    * This might not be the best way to do it, but this is as it has been working till now.
    * In order not to break existing functionality, for the time being this behaviour will
-   * be retained in any code changes. 
+   * be retained in any code changes.
    *
    * @param {string} text  text to split
    * @returns {Array<line>}
@@ -381,7 +381,7 @@ class LabelSplitter {
           for (let j = 0; j < blocks.length; j++) {
             const mod  = blocks[j].mod;
             const text = blocks[j].text;
-            this.lines.append(text, mod); 
+            this.lines.append(text, mod);
           }
         }
 
@@ -398,11 +398,11 @@ class LabelSplitter {
       } else {
         // widthConstraint.maximum NOT defined
         for (let i = 0; i < lineCount; i++) {
-          this.lines.newLine(nlLines[i]); 
+          this.lines.newLine(nlLines[i]);
         }
       }
     }
-   
+
     return this.lines.finalize();
   }
 
@@ -451,7 +451,7 @@ class LabelSplitter {
       const ch = s.text.charAt(s.position);
 
       const parsed = s.parseWS(ch)
-        || (/</.test(ch) && ( 
+        || (/</.test(ch) && (
              s.parseStartTag('bold', '<b>')
           || s.parseStartTag('ital', '<i>')
           || s.parseStartTag('mono', '<code>')
@@ -476,7 +476,7 @@ class LabelSplitter {
    * @returns {Array}
    */
   splitMarkdownBlocks(text) {
-    const s = new MarkupAccumulator(text); 
+    const s = new MarkupAccumulator(text);
     let beginable = true;
 
     const parseOverride = (ch) => {
@@ -557,9 +557,9 @@ class LabelSplitter {
 
 
   /**
-   * Determine the longest part of the sentence which still fits in the 
+   * Determine the longest part of the sentence which still fits in the
    * current max width.
-   * 
+   *
    * @param {Array} words  Array of strings signifying a text lines
    * @return {number}      index of first item in string making string go over max
    * @private
@@ -584,7 +584,7 @@ class LabelSplitter {
   /**
    * Determine the longest part of the string which still fits in the
    * current max width.
-   * 
+   *
    * @param {Array} words Array of strings signifying a text lines
    * @return {number} index of first item in string making string go over max
    */
@@ -602,13 +602,13 @@ class LabelSplitter {
 
   /**
    * Split the passed text into lines, according to width constraint (if any).
-   * 
+   *
    * The method assumes that the input string is a single line, i.e. without lines break.
    *
    * This method retains spaces, if still present (case `font.multi: false`).
    * A space which falls on an internal line break, will be replaced by a newline.
    * There is no special handling of tabs; these go along with the flow.
-   * 
+   *
    * @param {string} str
    * @param {string} [mod='normal']
    * @param {boolean} [appendLast=false]
@@ -650,9 +650,9 @@ class LabelSplitter {
         const text = words.slice(0, w).join("");
 
         if (w == words.length && appendLast) {
-          this.lines.append(text, mod); 
+          this.lines.append(text, mod);
         } else {
-          this.lines.newLine(text, mod); 
+          this.lines.newLine(text, mod);
         }
 
         // Adjust the word, so that the rest will be done next iteration
@@ -660,6 +660,6 @@ class LabelSplitter {
       }
     }
   }
-} 
+}
 
 export default LabelSplitter;

--- a/lib/network/options.js
+++ b/lib/network/options.js
@@ -168,7 +168,7 @@ const allOptions = {
     },
     selectionWidth: { 'function': 'function', number },
     selfReferenceSize: { number },
-    selfReference: { 
+    selfReference: {
       size: { number },
       angle: { number },
       renderBehindTheNode: { boolean: bool },
@@ -631,7 +631,7 @@ const configureOptions = {
     },
     selectionWidth: [1.5, 0, 5, 0.1],
     selfReferenceSize: [20, 0, 200, 1],
-    selfReference: { 
+    selfReference: {
       size: [20, 0, 200, 1],
       angle: [Math.PI / 2, -6 * Math.PI, 6 * Math.PI, Math.PI / 8],
       renderBehindTheNode: true,

--- a/lib/network/typedefs.js
+++ b/lib/network/typedefs.js
@@ -16,7 +16,7 @@
 
 /**
  * @typedef {{x:number, y:number}} Point
- * 
+ *
  * A point in view-coordinates.
  */
 

--- a/lib/shared/Validator.js
+++ b/lib/shared/Validator.js
@@ -79,7 +79,7 @@ class Validator {
       is_object = (Validator.getType(options[option]) === 'object');
     }
     else {
-      // Since all options in the reference are objects, we can check whether 
+      // Since all options in the reference are objects, we can check whether
       // they are supposed to be the object to look for the __type__ field.
       // if this is an object, we check if the correct type has been supplied to account for shorthand options.
     }

--- a/test/Label.test.js
+++ b/test/Label.test.js
@@ -7,7 +7,7 @@
  *
  * - html entities
  * - html unclosed or unopened tags
- * - html tag combinations with no font defined (e.g. bold within mono) 
+ * - html tag combinations with no font defined (e.g. bold within mono)
  * - Unit tests for bad font shorthands.
  *   Currently, only "size[px] name color" is valid, always 3 items with this exact spacing.
  *   All other combinations should either be rejected as error or handled gracefully.
@@ -106,7 +106,7 @@ describe('Network Label', function() {
   }
 
 
-  function checkProcessedLabels(label, text, expected) {   
+  function checkProcessedLabels(label, text, expected) {
     const ctx = new DummyContext();
 
     for (const i of Object.keys(text)) {
@@ -412,7 +412,7 @@ describe('Network Label', function() {
     let label = new Label({}, options);
 
     checkProcessedLabels(label, normal_text  , normal_widthConstraint_expected);
-    checkProcessedLabels(label, html_text    , multi_expected); 
+    checkProcessedLabels(label, html_text    , multi_expected);
 
     // Following is an unlucky selection, because the first line broken on the final character (space)
     // So we cheat a bit here
@@ -432,7 +432,7 @@ describe('Network Label', function() {
     const label = new Label({}, options);
 
     checkProcessedLabels(label, normal_text  , normal_widthConstraint_expected);
-    checkProcessedLabels(label, html_text    , html_widthConstraint_unchanged); 
+    checkProcessedLabels(label, html_text    , html_widthConstraint_unchanged);
     checkProcessedLabels(label, markdown_text, multi_expected);
 
     done();
@@ -474,14 +474,14 @@ describe('Node Labels', function() {
         }
       },
     ];
-  
+
     // create a network
     const container = document.getElementById('mynetwork');
     const data = {
         nodes: new DataSet(dataNodes),
         edges: []
     };
-  
+
     const options = {
       nodes: {
         font: {
@@ -501,7 +501,7 @@ describe('Node Labels', function() {
     if (newOptions !== undefined) {
       util.deepExtend(options, newOptions);
     }
-  
+
     const network = new Network(container, data, options);
     return [network, data, options];
   }
@@ -675,14 +675,14 @@ describe('Edge Labels', function() {
         }
       },
     ];
-  
+
     // create a network
     const container = document.getElementById('mynetwork');
     const data = {
         nodes: new DataSet(dataNodes),
         edges: new DataSet(dataEdges),
     };
-  
+
     const options = {
       edges: {
         font: {
@@ -694,7 +694,7 @@ describe('Edge Labels', function() {
     if (newOptions !== undefined) {
       util.deepExtend(options, newOptions);
     }
-  
+
     const network = new Network(container, data, options);
     return [network, data, options];
   }
@@ -804,7 +804,7 @@ describe('Shorthand Font Options', function() {
 
   function checkFont(opt, expectedLabel) {
     const expected = testFonts[expectedLabel];
- 
+
     util.forEach(expected, (item, key) => {
       assert.equal(opt[key], item);
     });
@@ -847,7 +847,7 @@ describe('Shorthand Font Options', function() {
         }
       }
     };
-  
+
     const network = new Network(container, data, options);
     return [network, data];
   }
@@ -860,14 +860,14 @@ describe('Shorthand Font Options', function() {
     // NOTE: 'mono' has its own global default font and size, which will
     //       trump any other font values set.
 
-    let opt = h.fontOption(1); 
+    let opt = h.fontOption(1);
     checkFont(opt, 'default');
     checkFont(opt.bold, 'font1');
     checkFont(opt.ital, 'font2');
     checkFont(opt.mono, 'monodef');           // Mono should have defaults
 
     // Node 2 should be using group1 options
-    opt = h.fontOption(2); 
+    opt = h.fontOption(2);
     checkFont(opt, 'font3');
     checkFont(opt.bold, 'font1');             // bold retains nodes default options
     checkFont(opt.ital, 'font2');             // ital retains nodes default options
@@ -876,14 +876,14 @@ describe('Shorthand Font Options', function() {
     assert.equal(opt.mono.size, 15);          // Own global default size
 
     // Node 3 should be using group2 options
-    opt = h.fontOption(3); 
+    opt = h.fontOption(3);
     checkFont(opt, 'default');
     checkFont(opt.bold, 'font4');
     checkFont(opt.ital, 'font2');
     checkFont(opt.mono, 'monodef'); // Mono should have defaults
 
     // Node 4 has its own base font definition
-    opt = h.fontOption(4); 
+    opt = h.fontOption(4);
     checkFont(opt, 'font5');
     checkFont(opt.bold, 'font1');
     checkFont(opt.ital, 'font2');
@@ -937,7 +937,7 @@ describe('Shorthand Font Options', function() {
     const h = new HelperNode(network);
     dynamicAdd1(network, data);
 
-    let opt = h.fontOption(1); 
+    let opt = h.fontOption(1);
     checkFont(opt, 'font5');                  // New base font
     checkFont(opt.bold, 'font1');
     checkFont(opt.ital, 'font4');             // New global node default
@@ -945,13 +945,13 @@ describe('Shorthand Font Options', function() {
     assert.equal(opt.mono.face, 'monospace');
     assert.equal(opt.mono.size, 15);
 
-    opt = h.fontOption(2); 
+    opt = h.fontOption(2);
     checkFont(opt, 'default');
     checkFont(opt.bold, 'font7');
     checkFont(opt.ital, 'font4');             // New global node default
     checkFont(opt.mono, 'monodef');           // Mono should have defaults again
 
-    opt = h.fontOption(3); 
+    opt = h.fontOption(3);
     checkFont(opt, 'font6');                  // New base font
     checkFont(opt.bold, 'font1');             // group bold option removed, using global default node
     checkFont(opt.ital, 'font4');             // New global node default
@@ -959,7 +959,7 @@ describe('Shorthand Font Options', function() {
     assert.equal(opt.mono.face, 'monospace');
     assert.equal(opt.mono.size, 15);
 
-    opt = h.fontOption(4); 
+    opt = h.fontOption(4);
     checkFont(opt, 'default');
     checkFont(opt.bold, 'font6');
     checkFont(opt.ital, 'font4');
@@ -969,22 +969,22 @@ describe('Shorthand Font Options', function() {
     done();
   });
 
-     
+
   it('deals with dynamic change of global node default', function (done) {
     const [network, data] = createNetwork();
     const h = new HelperNode(network);
     dynamicAdd1(network, data);  // Accumulate data of dynamic add
     dynamicAdd2(network, data);
 
-    let opt = h.fontOption(1); 
+    let opt = h.fontOption(1);
     checkFont(opt, 'font5');                  // Node instance value
-    checkFont(opt.bold, 'font5');             // bold def removed from global default node 
+    checkFont(opt.bold, 'font5');             // bold def removed from global default node
     checkFont(opt.ital, 'font5');             // idem
     assert.equal(opt.mono.color, '#050505');  // New color
     assert.equal(opt.mono.face, 'monospace');
     assert.equal(opt.mono.size, 15);
 
-    opt = h.fontOption(2); 
+    opt = h.fontOption(2);
     checkFont(opt, 'font7');                  // global node default applies for all settings
     checkFont(opt.bold, 'font7');
     checkFont(opt.ital, 'font7');
@@ -992,7 +992,7 @@ describe('Shorthand Font Options', function() {
     assert.equal(opt.mono.face, 'monospace');
     assert.equal(opt.mono.size, 15);
 
-    opt = h.fontOption(3); 
+    opt = h.fontOption(3);
     checkFont(opt, 'font6');                  // Group base font
     checkFont(opt.bold, 'font6');             // idem
     checkFont(opt.ital, 'font6');             // idem
@@ -1000,7 +1000,7 @@ describe('Shorthand Font Options', function() {
     assert.equal(opt.mono.face, 'monospace');
     assert.equal(opt.mono.size, 15);
 
-    opt = h.fontOption(4); 
+    opt = h.fontOption(4);
     checkFont(opt, 'font7');                  // global node default
     checkFont(opt.bold, 'font6');             // node instance bold
     checkFont(opt.ital, 'font7');             // global node default
@@ -1011,12 +1011,12 @@ describe('Shorthand Font Options', function() {
     done();
   });
 
-     
+
   it('deals with dynamic delete of shorthand options', function (done) {
     const [network, data] = createNetwork();
     const h = new HelperNode(network);
     dynamicAdd1(network, data);  // Accumulate data of previous dynamic steps
-    dynamicAdd2(network, data);  // idem 
+    dynamicAdd2(network, data);  // idem
 
     data.nodes.update([
       {id: 1, font: null},
@@ -1051,8 +1051,8 @@ describe('Shorthand Font Options', function() {
     });
 
     // global defaults for all
-    for (let n = 1; n <= 4; ++ n) { 
-      opt = h.fontOption(n); 
+    for (let n = 1; n <= 4; ++ n) {
+      opt = h.fontOption(n);
       checkFont(opt, 'font7');
       checkFont(opt.bold, 'font7');
       checkFont(opt.ital, 'font7');
@@ -1099,7 +1099,7 @@ describe('Shorthand Font Options', function() {
       {id: 1, label: '<b>1</b>', group: 'group1'},
       {
         // From example 1 in #3408
-        id: 6, 
+        id: 6,
         label: '<i>\uf286</i> <b>\uf2cd</b> colored glyph icon',
         shape: 'icon',
         group: 'colored',
@@ -1111,14 +1111,14 @@ describe('Shorthand Font Options', function() {
         }
       },
     ];
-  
+
     // create a network
     const container = document.getElementById('mynetwork');
     const data = {
         nodes: new DataSet(dataNodes),
         edges: []
     };
-  
+
     const options = {
       groups: {
         group1: {
@@ -1145,7 +1145,7 @@ describe('Shorthand Font Options', function() {
         },
       },
     };
-  
+
     const network = new Network(container, data, options);
 
     assert.equal(modBold(1).color, 'red');  // Group value
@@ -1183,8 +1183,8 @@ describe('Shorthand Font Options', function() {
     // console.log("===============");
     // console.log(fontOption(1));
 
-    assert.equal(modBold(1).color, '#343434');  // Reverts to default 
-    assert(!fontOption(1).multi);               // idem 
+    assert.equal(modBold(1).color, '#343434');  // Reverts to default
+    assert(!fontOption(1).multi);               // idem
     assert.equal(modBold(6).color, 'blue');     // unchanged
     assert(fontOption(6).multi);                // unchanged
 
@@ -1211,11 +1211,11 @@ describe('Shorthand Font Options', function() {
       lines: [{
         blocks: [{text: "Too  many    spaces     here!"}],
       }]
-    }, { 
+    }, {
       lines: [{
         blocks: [{text: "one two  three   four    five     six      ."}],
       }]
-    }, { 
+    }, {
       lines: [{
         blocks: [{text: "This thing:"}],
       }, {
@@ -1242,7 +1242,7 @@ describe('Shorthand Font Options', function() {
         }, {
           blocks: [{text: "     here!"}],
       }]
-    }, { 
+    }, {
       lines: [{
           blocks: [{text: "one two  three   "}],
         }, {
@@ -1250,7 +1250,7 @@ describe('Shorthand Font Options', function() {
         }, {
           blocks: [{text: "      ."}],
       }]
-    }, { 
+    }, {
       lines: [{
         blocks: [{text: "This thing:"}],
       }, {
@@ -1276,11 +1276,11 @@ describe('Shorthand Font Options', function() {
       lines: [{
         blocks: [{text: "Too many spaces here!"}],
       }]
-    }, { 
+    }, {
       lines: [{
         blocks: [{text: "one two three four five six ."}],
       }]
-    }, { 
+    }, {
       lines: [{
         blocks: [{text: "This thing:"}],
       }, {
@@ -1307,13 +1307,13 @@ describe('Shorthand Font Options', function() {
       }, {
         blocks: [{text: "here!"}],
       }]
-    }, { 
+    }, {
       lines: [{
         blocks: [{text: "one two three four"}],
       }, {
         blocks: [{text: "five six ."}],
       }]
-    }, { 
+    }, {
       lines: [{
         blocks: [{text: "This thing:"}],
       }, {
@@ -1412,7 +1412,7 @@ describe('Shorthand Font Options', function() {
 
 
   /**
-   * 
+   *
    * The test network is derived from example `network/nodeStyles/widthHeight.html`,
    * where the associated issue (i.e. widthConstraint values not copied) was most poignant.
    *
@@ -1435,14 +1435,14 @@ describe('Shorthand Font Options', function() {
       { id: 401, heightConstraint: { minimum: 100, valign: 'middle' }, label: 'node 401'},
       { id: 402, heightConstraint: { minimum: 100, valign: 'bottom' }, label: 'node 402'}
     ];
-  
+
     const edges = [
       { id: 1, from: 100, to: 210, label: "edge 1"},
       { id: 2, widthConstraint: 80, from: 210, to: 211, label: "edge 2"},
       { id: 3, heightConstraint: 90, from: 100, to: 220, label: "edge 3"},
       { id: 4, from: 401, to: 402, widthConstraint: { maximum: 150 }, label: "edge 12"},
     ];
-  
+
     const container = document.getElementById('mynetwork');
     const data = {
       nodes: nodes,
@@ -1564,7 +1564,7 @@ describe('Shorthand Font Options', function() {
       //label.getTextSize(ctx, false, false);  // Use this to determine the error thrown
 
       // There should not be a label for any of the cases
-      // 
+      //
       const labelVal = label.elementOptions.label;
       const validLabel = (typeof labelVal === 'string' && labelVal !== '');
       assert(!validLabel, "Unexpected label value '" + labelVal+ "' for " + text +" " + index);
@@ -1609,7 +1609,7 @@ describe('Shorthand Font Options', function() {
 
     //
     // Following extracted from example 'nodeLegend', where the problem was detected.
-    // 
+    //
     // In the example, only `label:null` was present. The weird thing is that it fails
     // in the example, but succeeds in the unit tests.
     // Kept in for regression testing.

--- a/test/Network.test.js
+++ b/test/Network.test.js
@@ -131,7 +131,7 @@ function createSampleNetwork(options) {
  *
  * Works on the network created by createSampleNetwork().
  *
- * This is actually a pathological case; there are two separate sub-networks and 
+ * This is actually a pathological case; there are two separate sub-networks and
  * a cluster is made of two nodes, each from one of the sub-networks.
  */
 function createCluster(network) {
@@ -306,7 +306,7 @@ describe('Network', function () {
   /**
    * Helper function for clustering
    */
-  function clusterTo(network, clusterId, nodeList, allowSingle) {  
+  function clusterTo(network, clusterId, nodeList, allowSingle) {
     const options = {
       joinCondition: function(node) {
         return nodeList.indexOf(node.id) !== -1;
@@ -342,11 +342,11 @@ describe('Network', function () {
       clusterTo(network, 'c1', [1,2,3]);
       data.nodes.remove(1);
       network.openCluster('c1');
-		  clusterTo(network, 'c1', [4], true);	
-		  clusterTo(network, 'c2', ['c1'], true);	
-		  clusterTo(network, 'c3', ['c2'], true);	
+		  clusterTo(network, 'c1', [4], true);
+		  clusterTo(network, 'c2', ['c1'], true);
+		  clusterTo(network, 'c3', ['c2'], true);
       data.nodes.remove(4);
-      
+
     } catch(e) {
       delete Array.prototype.foo;  // Remove it again so as not to confuse other tests.
       delete Object.prototype.bar;
@@ -380,7 +380,7 @@ describe('Network', function () {
     // The init should succeed without an error thrown.
     let options = {
       nodes: {
-        physics: false   // any value here triggered the error 
+        physics: false   // any value here triggered the error
       }
     };
     createSampleNetwork(options);
@@ -678,35 +678,35 @@ describe('Edge', function () {
   /**
    * Unit test for fix of #3500
    * Checking to make sure edges that become unconnected due to node removal get reconnected
-  */  
+  */
   it.skip('has reconnected edges (problems since mocha 4)', function (done) {
     const node1 = {id:1, label:"test1"};
     const node2 = {id:2, label:"test2"};
     const nodes = new DataSet([node1, node2]);
-  
+
     const edge = {id:1, from: 1, to:2};
     const edges = new DataSet([edge]);
 
     const data = {
         nodes: nodes,
         edges: edges
-    };    
+    };
 
     const container = document.getElementById('mynetwork');
     const network = new Network(container, data);
 
     //remove node causing edge to become disconnected
     nodes.remove(node2.id);
-    
+
     let foundEdge = network.body.edges[edge.id];
 
     assert.ok(foundEdge===undefined, "edge is still in state cache");
 
     //add node back reconnecting edge
     nodes.add(node2);
-    
+
     foundEdge = network.body.edges[edge.id];
-    
+
     assert.ok(foundEdge!==undefined, "edge is missing from state cache");
     done();
   });
@@ -724,20 +724,20 @@ describe('Clustering', function () {
     assertNumNodes(network, numNodes);
     assertNumEdges(network, numEdges);
 
-    clusterTo(network, 'c1', [3,4]);  
+    clusterTo(network, 'c1', [3,4]);
     numNodes += 1;                                    // A clustering node is now hiding two nodes
     numEdges += 1;                                    // One clustering edges now hiding two edges
     assertNumNodes(network, numNodes, numNodes - 2);
     assertNumEdges(network, numEdges, numEdges - 2);
 
     // Cluster of single node should fail, because by default allowSingleNodeCluster == false
-    clusterTo(network, 'c2', [14]);  
+    clusterTo(network, 'c2', [14]);
     assertNumNodes(network, numNodes, numNodes - 2);  // Nothing changed
     assertNumEdges(network, numEdges, numEdges - 2);
     assert(network.body.nodes['c2'] === undefined);  // Cluster not created
 
     // Redo with allowSingleNodeCluster == true
-    clusterTo(network, 'c2', [14], true);  
+    clusterTo(network, 'c2', [14], true);
     numNodes += 1;
     numEdges += 1;
     assertNumNodes(network, numNodes, numNodes - 3);
@@ -747,7 +747,7 @@ describe('Clustering', function () {
 
     // allowSingleNodeCluster: true with two nodes
     // removing one clustered node should retain cluster
-    clusterTo(network, 'c3', [11, 12], true);  
+    clusterTo(network, 'c3', [11, 12], true);
     numNodes += 1;                                   // Added cluster
     numEdges += 2;
     assertNumNodes(network, numNodes, 6);
@@ -755,7 +755,7 @@ describe('Clustering', function () {
 
     data.nodes.remove(12);
     assert(network.body.nodes['c3'] !== undefined);  // Cluster should still be present
-    numNodes -= 1;                                   // removed node 
+    numNodes -= 1;                                   // removed node
     numEdges -= 3;                                   // cluster edge C3-13 should be removed
     assertNumNodes(network, numNodes, 6);
     assertNumEdges(network, numEdges, 4);
@@ -767,9 +767,9 @@ describe('Clustering', function () {
     const [network, data] = sampleNetwork;
     let [, , numNodes, numEdges] = sampleNetwork;
     // Create a chain of nested clusters, three deep
-		clusterTo(network, 'c1', [4], true);	
-		clusterTo(network, 'c2', ['c1'], true);	
-		clusterTo(network, 'c3', ['c2'], true);	
+		clusterTo(network, 'c1', [4], true);
+		clusterTo(network, 'c2', ['c1'], true);
+		clusterTo(network, 'c3', ['c2'], true);
     numNodes += 3;
     numEdges += 3;
     assertNumNodes(network, numNodes, numNodes - 3);
@@ -955,7 +955,7 @@ describe('Clustering', function () {
      *
      * Ordering of output depends on the order in which they are defined
      * within nodes.clustering; strictly, speaking, the array and its items
-     * are collections, so order should not matter. 
+     * are collections, so order should not matter.
      */
     const collectClusters = function(network) {
       const clusters = [];
@@ -1041,19 +1041,19 @@ describe('Clustering', function () {
     const [network, data] = sampleNetwork;
     let [, , numNodes, numEdges] = sampleNetwork;
 
-    clusterTo(network, 'c1', [3,4]);  
+    clusterTo(network, 'c1', [3,4]);
     numNodes += 1;                                    // new cluster node
     numEdges += 1;                                    // 1 cluster edge expected
     assertNumNodes(network, numNodes, numNodes - 2);  // 2 clustered nodes
     assertNumEdges(network, numEdges, numEdges - 2);  // 2 edges hidden
 
-    clusterTo(network, 'c2', [2,'c1']);  
+    clusterTo(network, 'c2', [2,'c1']);
     numNodes += 1;                                    // new cluster node
     numEdges += 1;                                    // 2 cluster edges expected
     assertNumNodes(network, numNodes, numNodes - 4);  // 4 clustered nodes, including c1
     assertNumEdges(network, numEdges, numEdges - 4);  // 4 edges hidden, including edge for c1
 
-    clusterTo(network, 'c3', [1,'c2']);  
+    clusterTo(network, 'c3', [1,'c2']);
     // Attempt at visualization: parentheses belong to the cluster one level above
     //                   c3
     //             (       -c2    )
@@ -1072,7 +1072,7 @@ describe('Clustering', function () {
     let [network, data, numNodes, numEdges] = createSampleNetwork();
 
     // Simple case: cluster of two nodes, delete one node
-    clusterTo(network, 'c1', [3,4]);  
+    clusterTo(network, 'c1', [3,4]);
     numNodes += 1;                                    // new cluster node
     numEdges += 1;                                    // 1 cluster edge expected
     assertNumNodes(network, numNodes, numNodes - 2);  // 2 clustered nodes
@@ -1150,21 +1150,21 @@ describe('Clustering', function () {
     // One external connection
     [network, data, numNodes, numEdges] = createSampleNetwork();
     // 14-13-12-11 1-2-3-4
-    clusterTo(network, 'c1', [3,4]);  
+    clusterTo(network, 'c1', [3,4]);
     network.clustering.openCluster('c1', {});
     assertNumNodes(network, numNodes, numNodes); // Expecting same as original
     assertNumEdges(network, numEdges, numEdges);
 
     // Two external connections
-    clusterTo(network, 'c1', [2,3]);  
+    clusterTo(network, 'c1', [2,3]);
     network.clustering.openCluster('c1', {});
     assertNumNodes(network, numNodes, numNodes); // Expecting same as original
     assertNumEdges(network, numEdges, numEdges);
     assertEdgeLabels(network, data.edges, "c1(3-4) cluster opened");
 
     // One external connection to cluster
-    clusterTo(network, 'c1', [1,2]);  
-    clusterTo(network, 'c2', [3,4]);  
+    clusterTo(network, 'c1', [1,2]);
+    clusterTo(network, 'c2', [3,4]);
     // 14-13-12-11 c1(1-2-)-c2(-3-4)
     network.clustering.openCluster('c1', {});
     // 14-13-12-11 1-2-c2(-3-4)
@@ -1185,16 +1185,16 @@ describe('Clustering', function () {
     assertNumEdges(network, numEdges, numEdges);
     assertEdgeLabels(network, data.edges, "c1(1-2) c2(3-4) c1 cluster opened");
 
-    clusterTo(network, 'c1', [1,2]);  
+    clusterTo(network, 'c1', [1,2]);
     // 14-13-12-11-c1(-1-2-)-3-4
     numNodes += 1;
     numEdges += 2;
-    clusterTo(network, 'c2', [3,4]);  
+    clusterTo(network, 'c2', [3,4]);
     // 14-13-12-11-c1(-1-2-)-c2(-3-4)
     // NOTE: clustering edges are hidden by clustering here!
     numNodes += 1;
     numEdges += 1;
-    clusterTo(network, 'c3', [11,12]);  
+    clusterTo(network, 'c3', [11,12]);
     // 14-13-c3(-12-11-)-c1(-1-2-)-c2(-3-4)
     numNodes += 1;
     numEdges += 2;
@@ -1221,8 +1221,8 @@ describe('Clustering', function () {
 
     data.edges.update({ from: 1, to: 11, label: "1 to 11" })
     numEdges += 1;
-		clusterTo(network, 'c1', [3,4]);	
-		clusterTo(network, 'c2', [2,'c1']);	
+		clusterTo(network, 'c1', [3,4]);
+		clusterTo(network, 'c2', [2,'c1']);
 		clusterTo(network, 'c3', [1,'c2']);
     // Attempt at visualization: parentheses belong to the cluster one level above
     //                  -c3
@@ -1259,9 +1259,9 @@ describe('Clustering', function () {
     assertNumEdges(network, numEdges);
 
 
-		clusterTo(network, 'c0', [11,12]);	
-		clusterTo(network, 'c1', [3,4]);	
-		clusterTo(network, 'c2', [2,'c1']);	
+		clusterTo(network, 'c0', [11,12]);
+		clusterTo(network, 'c1', [3,4]);
+		clusterTo(network, 'c2', [2,'c1']);
 		clusterTo(network, 'c3', [1,'c2']);
     //                 +----------------+
     //                 |     c3         |
@@ -1304,13 +1304,13 @@ describe('Clustering', function () {
 
     // Open the top cluster
     network.clustering.openCluster('c3', {});
-    //                             
+    //
     //       +-------+     +----+
     //       |   c0  |     | c1 |
     // 14-13-|-12-11-|-1-2-|-3-4|
     //       |  |    |   | +----+
-    //       +-------+   |       
-    //          |        |       
+    //       +-------+   |
+    //          |        |
     //          |--------|
     //              (II)
     numNodes -= 1;

--- a/test/canvas-mock.js
+++ b/test/canvas-mock.js
@@ -62,7 +62,7 @@ function replaceCanvasContext (el) {
 /**
  * Overrides document.createElement(), in order to supply a custom canvas element.
  *
- * In the canvas element, getContext() is overridden in order to supply a simple 
+ * In the canvas element, getContext() is overridden in order to supply a simple
  * mock object for the 2D context. For all other elements, the call functions unchanged.
  *
  * The override is only done if there is no 2D context already present.
@@ -77,7 +77,7 @@ function overrideCreateElement(window) {
   const f = window.document.createElement;
 
   // Check if 2D context already present. That happens either when running in a browser,
-  // or this is node.js with 'canvas' installed. 
+  // or this is node.js with 'canvas' installed.
   const ctx = d.createElement('canvas').getContext('2d');
   if (ctx !== null && ctx !== undefined) {
     //console.log('2D context is present, no need to override');


### PR DESCRIPTION
Trailing spaces are invisible to some and annoying to others. Also some editors remove them by default which leads to weird unrelated changes in PRs and then misleading git blame or annoying exchanges with contributors about restoring the spaces.

PS: Reformatting also changes what git blame reports but with commits like “style: eslint --fix” it's immediately obvious what happened.