### PR TITLE
feat(node-custom-shape): return draw function for different layers 

### DIFF
--- a/cypress/integration/visual/z-index.spec.ts
+++ b/cypress/integration/visual/z-index.spec.ts
@@ -1,4 +1,5 @@
 const EXTERNAL_LABEL_SHAPES = new Set<string>([
+  "custom",
   "diamond",
   "dot",
   "hexagon",
@@ -53,6 +54,24 @@ context("Z-index", (): void => {
                   color: "green",
                   size: 40,
                 },
+                ctxRenderer:
+                  "" +
+                  (({ ctx, x, y }: any): any => {
+                    const size = 300;
+                    const left = x - size / 2;
+                    const top = y - size / 2;
+                    return {
+                      drawNode() {
+                        ctx.fillStyle = "purple";
+                        ctx.fillRect(left, top, size, size);
+                      },
+                      drawExternalLabel() {
+                        ctx.font = "200px serif";
+                        ctx.fillStyle = "green";
+                        ctx.fillText("████", left, y + size);
+                      },
+                    };
+                  }),
               },
               {
                 id: 3,
@@ -110,7 +129,7 @@ context("Z-index", (): void => {
               },
             ],
           },
-          { requireNewerVersionThan: "8.0.1" }
+          { requireNewerVersionThan: "8.0.2" }
         );
       });
     }

--- a/cypress/pages/standard-cytest-script.ts
+++ b/cypress/pages/standard-cytest-script.ts
@@ -52,6 +52,20 @@ type VisUtil = typeof visUtil;
   );
   console.info("config", config);
 
+  // Turn stringified fuctions into actual executable function.
+  for (const node of config?.nodes ?? []) {
+    if (node?.ctxRenderer != null) {
+      node.ctxRenderer = new Function(
+        "payload",
+        [
+          '"use strict";',
+          "",
+          "return (" + node.ctxRenderer + ")(payload);",
+        ].join("\n")
+      );
+    }
+  }
+
   const baseURL =
     config.version == null
       ? "../.."

--- a/docs/network/nodes.html
+++ b/docs/network/nodes.html
@@ -424,10 +424,26 @@ network.setOptions(options);
             <td>Function</td>
             <td><code>undefined</code></td>
             <td>
-                <p>The function contains these props:</p>
-                <pre class="code">function({ ctx, x, y, state: { selected, hover }, style, label }) {...}</pre>
+                <p>The function inputs and outputs look like:</p>
+                <pre class="code">
+function ctxRenderer({ ctx, x, y, state: { selected, hover }, style, label }) {
+  // do some math here
+  return {
+    // bellow arrows
+    // primarily meant for nodes and the labels inside of their boundaries
+    drawNode() {
+      ctx.drawSomeNode();
+    },
+    // above arrows
+    // primarily meant for labels outside of the node
+    drawExternalLabel() {
+      ctx.drawSomeTextOutsideOfTheNode();
+    },
+  };
+}
+                </pre>
                 <p>
-                    This function allows to draw any canvas shapes and lines (see guide to how to draw shapes <a href="https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes">here</a>)
+                    This function allows to draw any canvas shapes and lines (see guide to how to draw shapes <a href="https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes">here</a>).
                     This property is used only when the property <code>shape</code> is <code>'custom'</code>. 
                 </p>
                 example: 

--- a/lib/network/modules/components/nodes/shapes/CustomShape.js
+++ b/lib/network/modules/components/nodes/shapes/CustomShape.js
@@ -28,9 +28,41 @@ class CustomShape extends ShapeBase {
    * @param {boolean} selected
    * @param {boolean} hover
    * @param {ArrowOptions} values
+   *
+   * @returns {Object} Callbacks to draw later on different layers.
    */
   draw(ctx, x, y, selected, hover, values) {
-    this._drawShape(ctx, 'custom', 4, x, y, selected, hover, values, this.ctxRenderer);
+    this.resize(ctx, selected, hover, values);
+    this.left = x - this.width / 2;
+    this.top = y - this.height / 2;
+
+    // Guard right away because someone may just draw in the function itself.
+    ctx.save();
+    const drawLater = this.ctxRenderer({
+      ctx,
+      x,
+      y,
+      state: { selected, hover },
+      style: { ...values },
+      label: this.options.label,
+    });
+    // Render the node shape bellow arrows.
+    if (drawLater.drawNode != null) {
+      drawLater.drawNode();
+    }
+    ctx.restore();
+
+    if (drawLater.drawExternalLabel) {
+      // Guard the external label (above arrows) drawing function.
+      const drawExternalLabel = drawLater.drawExternalLabel;
+      drawLater.drawExternalLabel = () => {
+        ctx.save();
+        drawExternalLabel();
+        ctx.restore();
+      };
+    }
+
+    return drawLater;
   }
 
   /**

--- a/lib/network/modules/components/nodes/util/ShapeBase.js
+++ b/lib/network/modules/components/nodes/util/ShapeBase.js
@@ -43,26 +43,18 @@ class ShapeBase extends NodeBase {
    * @param {boolean} selected
    * @param {boolean} hover
    * @param {ArrowOptions} values
-   * @param {function} customRenderer - a custom shape renderer similar to getShape(shape) functions
    * @private
    *
    * @returns {Object} Callbacks to draw later on higher layers.
    */
-  _drawShape(ctx, shape, sizeMultiplier, x, y, selected, hover, values, customRenderer) {
+  _drawShape(ctx, shape, sizeMultiplier, x, y, selected, hover, values) {
     this.resize(ctx, selected, hover, values);
     this.left = x - this.width / 2;
     this.top = y - this.height / 2;
 
-    if (shape === 'custom') {
-      ctx.save();
-      customRenderer({ ctx, x, y, state: { selected, hover }, style: { ...values }, label: this.options.label });
-      ctx.restore();
-      return
-    } else {
-      this.initContextForDraw(ctx, values);
-      getShape(shape)(ctx, x, y, values.size);
-      this.performFill(ctx, values);
-    }
+    this.initContextForDraw(ctx, values);
+    getShape(shape)(ctx, x, y, values.size);
+    this.performFill(ctx, values);
 
     if (this.options.icon !== undefined) {
       if (this.options.icon.code !== undefined) {


### PR DESCRIPTION
Basically the same as #932, it allows people to return an object (more props can be added without breaking changes or old props can receive special treatment to keep backwards compatibility) render something bellow/before arrows (`drawNode`) or above/after them (`drawExternalLabel`), the names are based on the primary purpose of those functions, though they can be used in any way that works of course. The rendering in the function itself will work as before so no breaking changes here.

Closes #883.

PS: The Z index visual regression test was extended to test the custom shape.