### PR TITLE
feat(node-ctx-renderer): add node id

### DIFF
--- a/docs/network/nodes.html
+++ b/docs/network/nodes.html
@@ -426,7 +426,7 @@ network.setOptions(options);
             <td>
                 <p>The function inputs and outputs look like:</p>
                 <pre class="code">
-function ctxRenderer({ ctx, x, y, state: { selected, hover }, style, label }) {
+function ctxRenderer({ ctx, id, x, y, state: { selected, hover }, style, label }) {
   // do some math here
   return {
     // bellow arrows

--- a/examples/network/nodeStyles/shapes.html
+++ b/examples/network/nodeStyles/shapes.html
@@ -52,7 +52,7 @@
           id: 36, 
           label: 'custom', 
           shape: 'custom', 
-          ctxRenderer: ({ ctx, x, y, state: { selected, hover }, style }) => {
+          ctxRenderer: ({ ctx, id, x, y, state: { selected, hover }, style }) => {
             const r = style.size;
             const drawNode = () => {
               ctx.beginPath();

--- a/lib/network/modules/components/nodes/shapes/CustomShape.js
+++ b/lib/network/modules/components/nodes/shapes/CustomShape.js
@@ -40,6 +40,7 @@ class CustomShape extends ShapeBase {
     ctx.save();
     const drawLater = this.ctxRenderer({
       ctx,
+      id: this.options.id,
       x,
       y,
       state: { selected, hover },


### PR DESCRIPTION
Add node id to the custom ctx renderer function's arguments so that users can distinguish individual nodes.

Closes #979.