### PR TITLE
fix(kamada-kawai): don't reposition fixed nodes

### DIFF
--- a/cypress/integration/visual/initial-positioning.no-fixed-no-positions.json
+++ b/cypress/integration/visual/initial-positioning.no-fixed-no-positions.json
@@ -1,0 +1,90 @@
+{
+  "nodes": [
+    {
+      "id": 0,
+      "type": "A",
+      "label": "A Node 1",
+      "color": "orange"
+    },
+    {
+      "id": 1,
+      "type": "A",
+      "label": "A node 2",
+      "color": "orange"
+    },
+    {
+      "id": 2,
+      "type": "A",
+      "label": "A node 3",
+      "color": "orange"
+    },
+    {
+      "id": 3,
+      "type": "A",
+      "label": "A Node 4",
+      "color": "orange"
+    },
+    {
+      "id": 4,
+      "type": "A",
+      "label": "A Node 5",
+      "color": "orange"
+    },
+
+    {
+      "id": 5,
+      "type": "B",
+      "label": "B Node 1"
+    },
+    {
+      "id": 6,
+      "type": "B",
+      "label": "B Node 2"
+    },
+    {
+      "id": 7,
+      "type": "B",
+      "label": "B Node "
+    },
+    {
+      "id": 8,
+      "type": "B",
+      "label": "B Node "
+    },
+    {
+      "id": 9,
+      "type": "B",
+      "label": "B Node "
+    },
+    {
+      "id": 10,
+      "type": "B",
+      "label": "B Node "
+    },
+    {
+      "id": 11,
+      "type": "B",
+      "label": "B Node "
+    },
+    {
+      "id": 12,
+      "type": "B",
+      "label": "B Node "
+    }
+  ],
+
+  "edges": [
+    { "from": 0, "to": 1 },
+    { "from": 1, "to": 2 },
+    { "from": 1, "to": 3 },
+    { "from": 1, "to": 4 },
+    { "from": 2, "to": 5 },
+    { "from": 3, "to": 6 },
+    { "from": 4, "to": 7 },
+    { "from": 4, "to": 8 },
+    { "from": 4, "to": 9 },
+    { "from": 4, "to": 10 },
+    { "from": 4, "to": 11 },
+    { "from": 4, "to": 12 }
+  ]
+}

--- a/cypress/integration/visual/initial-positioning.no-fixed-some-positions.json
+++ b/cypress/integration/visual/initial-positioning.no-fixed-some-positions.json
@@ -1,0 +1,100 @@
+{
+  "nodes": [
+    {
+      "id": 0,
+      "type": "A",
+      "label": "A Node 1",
+      "color": "orange",
+      "x": -50,
+      "y": -50
+    },
+    {
+      "id": 1,
+      "type": "A",
+      "label": "A node 2",
+      "color": "orange",
+      "x": -50,
+      "y": 50
+    },
+    {
+      "id": 2,
+      "type": "A",
+      "label": "A node 3",
+      "color": "orange",
+      "x": -150,
+      "y": 50
+    },
+    {
+      "id": 3,
+      "type": "A",
+      "label": "A Node 4",
+      "color": "orange",
+      "x": 50,
+      "y": 50
+    },
+    {
+      "id": 4,
+      "type": "A",
+      "label": "A Node 5",
+      "color": "orange",
+      "x": -50,
+      "y": 150
+    },
+
+    {
+      "id": 5,
+      "type": "B",
+      "label": "B Node 1"
+    },
+    {
+      "id": 6,
+      "type": "B",
+      "label": "B Node 2"
+    },
+    {
+      "id": 7,
+      "type": "B",
+      "label": "B Node "
+    },
+    {
+      "id": 8,
+      "type": "B",
+      "label": "B Node "
+    },
+    {
+      "id": 9,
+      "type": "B",
+      "label": "B Node "
+    },
+    {
+      "id": 10,
+      "type": "B",
+      "label": "B Node "
+    },
+    {
+      "id": 11,
+      "type": "B",
+      "label": "B Node "
+    },
+    {
+      "id": 12,
+      "type": "B",
+      "label": "B Node "
+    }
+  ],
+
+  "edges": [
+    { "from": 0, "to": 1 },
+    { "from": 1, "to": 2 },
+    { "from": 1, "to": 3 },
+    { "from": 1, "to": 4 },
+    { "from": 2, "to": 5 },
+    { "from": 3, "to": 6 },
+    { "from": 4, "to": 7 },
+    { "from": 4, "to": 8 },
+    { "from": 4, "to": 9 },
+    { "from": 4, "to": 10 },
+    { "from": 4, "to": 11 },
+    { "from": 4, "to": 12 }
+  ]
+}

--- a/cypress/integration/visual/initial-positioning.some-fixed-some-positions.json
+++ b/cypress/integration/visual/initial-positioning.some-fixed-some-positions.json
@@ -1,0 +1,105 @@
+{
+  "nodes": [
+    {
+      "id": 0,
+      "type": "A",
+      "label": "A Node 1",
+      "color": "orange",
+      "fixed": true,
+      "x": -50,
+      "y": -50
+    },
+    {
+      "id": 1,
+      "type": "A",
+      "label": "A node 2",
+      "color": "orange",
+      "fixed": true,
+      "x": -50,
+      "y": 50
+    },
+    {
+      "id": 2,
+      "type": "A",
+      "label": "A node 3",
+      "color": "orange",
+      "fixed": true,
+      "x": -150,
+      "y": 50
+    },
+    {
+      "id": 3,
+      "type": "A",
+      "label": "A Node 4",
+      "color": "orange",
+      "fixed": true,
+      "x": 50,
+      "y": 50
+    },
+    {
+      "id": 4,
+      "type": "A",
+      "label": "A Node 5",
+      "color": "orange",
+      "fixed": true,
+      "x": -50,
+      "y": 150
+    },
+
+    {
+      "id": 5,
+      "type": "B",
+      "label": "B Node 1"
+    },
+    {
+      "id": 6,
+      "type": "B",
+      "label": "B Node 2"
+    },
+    {
+      "id": 7,
+      "type": "B",
+      "label": "B Node "
+    },
+    {
+      "id": 8,
+      "type": "B",
+      "label": "B Node "
+    },
+    {
+      "id": 9,
+      "type": "B",
+      "label": "B Node "
+    },
+    {
+      "id": 10,
+      "type": "B",
+      "label": "B Node "
+    },
+    {
+      "id": 11,
+      "type": "B",
+      "label": "B Node "
+    },
+    {
+      "id": 12,
+      "type": "B",
+      "label": "B Node "
+    }
+  ],
+
+  "edges": [
+    { "from": 0, "to": 1 },
+    { "from": 1, "to": 2 },
+    { "from": 1, "to": 3 },
+    { "from": 1, "to": 4 },
+    { "from": 2, "to": 5 },
+    { "from": 3, "to": 6 },
+    { "from": 4, "to": 7 },
+    { "from": 4, "to": 8 },
+    { "from": 4, "to": 9 },
+    { "from": 4, "to": 10 },
+    { "from": 4, "to": 11 },
+    { "from": 4, "to": 12 }
+  ]
+}

--- a/cypress/integration/visual/initial-positioning.spec.ts
+++ b/cypress/integration/visual/initial-positioning.spec.ts
@@ -1,0 +1,29 @@
+import NO_FIXED_NO_POSITIONS from "./initial-positioning.no-fixed-no-positions.json";
+import NO_FIXED_SOME_POSITIONS from "./initial-positioning.no-fixed-some-positions.json";
+import SOME_FIXED_SOME_POSITIONS from "./initial-positioning.some-fixed-some-positions.json";
+
+context("Initial positioning", (): void => {
+  it("Nothing fixed, no positions", function (): void {
+    cy.visSimpleCanvasSnapshot(
+      "no-fixed-no-positions",
+      { ...NO_FIXED_NO_POSITIONS },
+      { requireNewerVersionThan: "8.3.0" }
+    );
+  });
+
+  it("Nothing fixed, some positions", function (): void {
+    cy.visSimpleCanvasSnapshot(
+      "no-fixed-some-positions",
+      { ...NO_FIXED_SOME_POSITIONS },
+      { requireNewerVersionThan: "8.3.0" }
+    );
+  });
+
+  it("Some fixed, some positions", function (): void {
+    cy.visSimpleCanvasSnapshot(
+      "some-fixed-some-positions",
+      { ...SOME_FIXED_SOME_POSITIONS },
+      { requireNewerVersionThan: "8.3.0" }
+    );
+  });
+});

--- a/lib/network/modules/KamadaKawai.js
+++ b/lib/network/modules/KamadaKawai.js
@@ -97,7 +97,12 @@ class KamadaKawai {
     for (let nodeIdx = 0; nodeIdx < nodesArray.length; nodeIdx++) {
       const m = nodesArray[nodeIdx];
       // by not evaluating nodes with predefined positions we should only move nodes that have no positions.
-      if ((nodes[m].predefinedPosition === false || nodes[m].isCluster === true && ignoreClusters === true) || nodes[m].options.fixed.x === true || nodes[m].options.fixed.y === true) {
+      if (
+        nodes[m].predefinedPosition !== true ||
+        (nodes[m].isCluster === true && ignoreClusters === true) ||
+        nodes[m].options.fixed.x !== true ||
+        nodes[m].options.fixed.y !== true
+      ) {
         const [delta_m,dE_dx,dE_dy] = this._getEnergy(m);
         if (maxEnergy < delta_m) {
           maxEnergy = delta_m;


### PR DESCRIPTION
Kamada Kawai used to reposition fixed nodes, however fixed nodes should not move at all.

This PR fixes that and also includes visual regression test.

Closes #991.