### PR TITLE
perf(resizing): use ResizeObserver if available

### DIFF
--- a/examples/network/other/automaticResizing.html
+++ b/examples/network/other/automaticResizing.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Vis Network | Other | Automatic Resizing</title>
+
+    <script
+      type="text/javascript"
+      src="../../../standalone/umd/vis-network.min.js"
+    ></script>
+
+    <style type="text/css">
+      #mynetwork {
+        width: 400px;
+        height: 400px;
+        border: 1px solid lightgray;
+      }
+    </style>
+  </head>
+  <body>
+    Resizing is immediate in all decent browsers but in IE11 it may take up to a
+    second to take effect.
+
+    <div id="mynetwork"></div>
+
+    <script type="text/javascript">
+      // resize the canvas
+      setInterval(() => {
+        document.querySelector("#mynetwork").style.width =
+          Math.ceil(300 + 200 * Math.random()) + "px";
+        document.querySelector("#mynetwork").style.height =
+          Math.ceil(300 + 200 * Math.random()) + "px";
+      }, 1951);
+
+      // create an array with nodes
+      var nodes = new vis.DataSet([
+        { id: 1, label: "Node 1" },
+        { id: 2, label: "Node 2" },
+        { id: 3, label: "Node 3" },
+        { id: 4, label: "Node 4" },
+        { id: 5, label: "Node 5" },
+      ]);
+
+      // create an array with edges
+      var edges = new vis.DataSet([
+        { from: 1, to: 3 },
+        { from: 1, to: 2 },
+        { from: 2, to: 4 },
+        { from: 2, to: 5 },
+        { from: 3, to: 3 },
+      ]);
+
+      // create a network
+      var container = document.getElementById("mynetwork");
+      var data = {
+        nodes: nodes,
+        edges: edges,
+      };
+      var options = {};
+      var network = new vis.Network(container, data, options);
+    </script>
+  </body>
+</html>

--- a/lib/network/modules/Canvas.js
+++ b/lib/network/modules/Canvas.js
@@ -20,11 +20,10 @@ class Canvas {
   constructor(body) {
     this.body = body;
     this.pixelRatio = 1;
-    this.resizeTimer = undefined;
-    this.resizeFunction = this._onResize.bind(this);
     this.cameraState = {};
     this.initialized = false;
     this.canvasViewCenter = {};
+    this._cleanupCallbacks = [];
 
     this.options = {};
     this.defaultOptions = {
@@ -67,17 +66,42 @@ class Canvas {
       selectiveDeepExtend(fields,this.options, options);
     }
 
+    // Automatically adapt to changing size of the container element.
+    this._cleanUp();
     if (this.options.autoResize === true) {
-      // automatically adapt to a changing size of the browser.
-      this._cleanUp();
-      this.resizeTimer = setInterval(() => {
-        const changed = this.setSize();
-        if (changed === true) {
-          this.body.emitter.emit("_requestRedraw");
-        }
-      }, 1000);
-      this.resizeFunction = this._onResize.bind(this);
-      addEventListener(window,'resize',this.resizeFunction);
+      if (window.ResizeObserver) {
+        // decent browsers, immediate reactions
+        const observer = new ResizeObserver(() => {
+          const changed = this.setSize();
+          if (changed === true) {
+            this.body.emitter.emit("_requestRedraw");
+          }
+        });
+        const { frame } = this;
+
+        observer.observe(frame);
+        this._cleanupCallbacks.push(() => {
+          observer.unobserve(frame);
+        });
+      } else {
+        // IE11, continous polling
+        const resizeTimer = setInterval(() => {
+          const changed = this.setSize();
+          if (changed === true) {
+            this.body.emitter.emit("_requestRedraw");
+          }
+        }, 1000);
+        this._cleanupCallbacks.push(() => {
+          clearInterval(resizeTimer);
+        });
+      }
+
+      // Automatically adapt to changing size of the browser.
+      const resizeFunction = this._onResize.bind(this);
+      addEventListener(window, "resize", resizeFunction);
+      this._cleanupCallbacks.push(() => {
+        removeEventListener(window, "resize", resizeFunction);
+      });
     }
   }
 
@@ -85,12 +109,16 @@ class Canvas {
    * @private
    */
   _cleanUp() {
-    // automatically adapt to a changing size of the browser.
-    if (this.resizeTimer !== undefined) {
-      clearInterval(this.resizeTimer);
-    }
-    removeEventListener(window,'resize',this.resizeFunction);
-    this.resizeFunction = undefined;
+    this._cleanupCallbacks
+      .splice(0)
+      .reverse()
+      .forEach((callback) => {
+        try {
+          callback();
+        } catch (error) {
+          console.error(error);
+        }
+      });
   }
 
   /**


### PR DESCRIPTION
This removes the delay after container element dimensions are changed and before the canvas pixel dimensions are changed.

Doesn't work in IE11, the old behavior is retained there.

Closes #1011.