### PR TITLE
feat(data): allow custom DataSet/View implementations

### DIFF
--- a/lib/network/modules/EdgesHandler.js
+++ b/lib/network/modules/EdgesHandler.js
@@ -1,5 +1,5 @@
 import { deepExtend, forEach } from "vis-util/esnext";
-import { DataSet, DataView } from "vis-data/esnext";
+import { DataSet, isDataViewLike } from "vis-data/esnext";
 import Edge from "./components/Edge";
 
 /**
@@ -248,13 +248,13 @@ class EdgesHandler {
    * Load edges by reading the data table
    *
    * @param {Array | DataSet | DataView} edges    The data containing the edges.
-   * @param {boolean} [doNotEmit=false]
+   * @param {boolean} [doNotEmit=false] - Suppress data changed event.
    * @private
    */
   setData(edges, doNotEmit = false) {
     const oldEdgesData = this.body.data.edges;
 
-    if (edges instanceof DataSet || edges instanceof DataView) {
+    if (isDataViewLike("id", edges)) {
       this.body.data.edges = edges;
     } else if (Array.isArray(edges)) {
       this.body.data.edges = new DataSet();

--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -1,5 +1,5 @@
 import { bridgeObject, forEach } from "vis-util/esnext";
-import { DataSet, DataView } from "vis-data/esnext";
+import { DataSet, isDataViewLike } from "vis-data/esnext";
 import Node from "./components/Node";
 
 /**
@@ -245,13 +245,13 @@ class NodesHandler {
    * Set a data set with nodes for the network
    *
    * @param {Array | DataSet | DataView} nodes         The data containing the nodes.
-   * @param {boolean} [doNotEmit=false]
+   * @param {boolean} [doNotEmit=false] - Suppress data changed event.
    * @private
    */
   setData(nodes, doNotEmit = false) {
     const oldNodesData = this.body.data.nodes;
 
-    if (nodes instanceof DataSet || nodes instanceof DataView) {
+    if (isDataViewLike("id", nodes)) {
       this.body.data.nodes = nodes;
     } else if (Array.isArray(nodes)) {
       this.body.data.nodes = new DataSet();


### PR DESCRIPTION
This tests that the methods and properties are implemented instead of checking the prototype. Thanks to this it is now possible to use a different DataSet or DataView without extending the Vis one. This also removes some interoperability issues of the standalone build when used toghether with other Vis family libraries.