### PR TITLE
fix: purge instanceof Array from the codebase

### DIFF
--- a/lib/shared/Configurator.js
+++ b/lib/shared/Configurator.js
@@ -67,7 +67,7 @@ class Configurator {
       let enabled = true;
       if (typeof options === "string") {
         this.options.filter = options;
-      } else if (options instanceof Array) {
+      } else if (Array.isArray(options)) {
         this.options.filter = options.join();
       } else if (typeof options === "object") {
         if (options == null) {
@@ -616,7 +616,7 @@ class Configurator {
           // if needed we must go deeper into the object.
           if (show === false) {
             if (
-              !(item instanceof Array) &&
+              !Array.isArray(item) &&
               typeof item !== "string" &&
               typeof item !== "boolean" &&
               item instanceof Object
@@ -632,7 +632,7 @@ class Configurator {
           visibleInSet = true;
           const value = this._getValue(newPath);
 
-          if (item instanceof Array) {
+          if (Array.isArray(item)) {
             this._handleArray(item, value, newPath);
           } else if (typeof item === "string") {
             this._makeTextInput(item, value, newPath);

--- a/test/Network.test.js
+++ b/test/Network.test.js
@@ -49,7 +49,7 @@ function merge(a, b) {
  * Load legacy-style (i.e. not module) javascript files into the given context.
  */
 function include(list, context) {
-  if (!(list instanceof Array)) {
+  if (!Array.isArray(list)) {
     list = [list];
   }
 


### PR DESCRIPTION
Array.isArray works with arrays that came from other contexts like web workers, instanceof Array wouldn't consider such array to be an array even though it is perfectly valid array.