### PR TITLE
fix(selection): highlight selected nodes when set programatically

### DIFF
--- a/cypress/integration/visual/selection.spec.ts
+++ b/cypress/integration/visual/selection.spec.ts
@@ -1,31 +1,32 @@
-import { Point, VisEvent } from "../helpers";
+context("Selection", (): void => {
+  beforeEach((): void => {
+    cy.visVisitUniversal(
+      {
+        nodes: [
+          { id: "N_1", label: "node 1", x: 0, y: 0 },
+          { id: "N_2", label: "node 2", x: 200, y: 0 },
+          { id: "N_3", label: "node 3", x: 0, y: 200 },
+          { id: "N_4", label: "node 4", x: -200, y: 0 },
+          { id: "N_5", label: "node 5", x: 0, y: -200 },
+        ],
+        edges: [
+          { id: "E_1-2", label: "edge 1-2", from: "N_1", to: "N_2" },
+          { id: "E_1-3", label: "edge 1-3", from: "N_1", to: "N_3" },
+          { id: "E_1-4", label: "edge 1-4", from: "N_1", to: "N_4" },
+          { id: "E_1-5", label: "edge 1-5", from: "N_1", to: "N_5" },
 
-const NETWORK_DATA = {
-  nodes: [
-    { id: "N_1", label: "node 1", x: 0, y: 0 },
-    { id: "N_2", label: "node 2", x: 200, y: 0 },
-    { id: "N_3", label: "node 3", x: 0, y: 200 },
-    { id: "N_4", label: "node 4", x: -200, y: 0 },
-    { id: "N_5", label: "node 5", x: 0, y: -200 },
-  ],
-  edges: [
-    { id: "E_1-2", label: "edge 1-2", from: "N_1", to: "N_2" },
-    { id: "E_1-3", label: "edge 1-3", from: "N_1", to: "N_3" },
-    { id: "E_1-4", label: "edge 1-4", from: "N_1", to: "N_4" },
-    { id: "E_1-5", label: "edge 1-5", from: "N_1", to: "N_5" },
+          { id: "E_2-3", label: "edge 2-3", from: "N_2", to: "N_3" },
+          { id: "E_3-4", label: "edge 3-4", from: "N_3", to: "N_4" },
+          { id: "E_4-5", label: "edge 4-5", from: "N_4", to: "N_5" },
+          { id: "E_5-2", label: "edge 5-2", from: "N_5", to: "N_2" },
+        ],
+        physics: false,
+      },
+      { requireNewerVersionThan: "8.5.0" }
+    );
+  });
 
-    { id: "E_2-3", label: "edge 2-3", from: "N_2", to: "N_3" },
-    { id: "E_3-4", label: "edge 3-4", from: "N_3", to: "N_4" },
-    { id: "E_4-5", label: "edge 4-5", from: "N_4", to: "N_5" },
-    { id: "E_5-2", label: "edge 5-2", from: "N_5", to: "N_2" },
-  ],
-  physics: false,
-};
-
-context("Drags", (): void => {
   it("Select one by click", function (): void {
-    cy.visVisitUniversal(NETWORK_DATA);
-
     cy.visClickPoint({ x: 500 + 0, y: 500 + 0 });
     cy.visAssertSelection({
       nodes: ["N_1"],
@@ -37,10 +38,11 @@ context("Drags", (): void => {
       nodes: ["N_2"],
       edges: ["E_5-2", "E_1-2", "E_2-3"],
     });
+
+    cy.visSnapshotOpenedPage("select-one-by-click");
   });
 
   it("Select none by single drag", function (): void {
-    cy.visVisitUniversal(NETWORK_DATA);
     cy.visDrag([
       {
         from: { x: 500 + 200 + 70, y: 500 + 200 - 70 },
@@ -53,10 +55,11 @@ context("Drags", (): void => {
       nodes: [],
       edges: [],
     });
+
+    cy.visSnapshotOpenedPage("select-none-by-single-drag");
   });
 
   it("Select one by single drag (TL to BR)", function (): void {
-    cy.visVisitUniversal(NETWORK_DATA);
     cy.visDrag([
       {
         from: { x: 500 + 0 - 70, y: 500 + 0 - 70 },
@@ -69,10 +72,11 @@ context("Drags", (): void => {
       nodes: ["N_1"],
       edges: ["E_1-2", "E_1-3", "E_1-4", "E_1-5"],
     });
+
+    cy.visSnapshotOpenedPage("select-one-by-single-drag-(TL_to_BR)");
   });
 
   it("Select three by single drag (BR to TL)", function (): void {
-    cy.visVisitUniversal(NETWORK_DATA);
     cy.visDrag([
       {
         from: { x: 500 + 200 + 70, y: 500 + 200 + 70 },
@@ -85,11 +89,11 @@ context("Drags", (): void => {
       nodes: ["N_1", "N_2", "N_3"],
       edges: ["E_1-2", "E_1-3", "E_1-4", "E_1-5", "E_3-4", "E_2-3", "E_5-2"],
     });
+
+    cy.visSnapshotOpenedPage("select-three-by-single-drag-(BR_to_TL)");
   });
 
   it("Select three by two drags (TR to BL then BL to TR)", function (): void {
-    cy.visVisitUniversal(NETWORK_DATA);
-
     cy.visDrag([
       {
         from: { x: 500 + 0 + 70, y: 500 + 0 - 70 },
@@ -115,5 +119,20 @@ context("Drags", (): void => {
       nodes: ["N_1", "N_2", "N_3"],
       edges: ["E_1-2", "E_1-3", "E_1-4", "E_1-5", "E_3-4", "E_2-3", "E_5-2"],
     });
+
+    cy.visSnapshotOpenedPage(
+      "select-three-by-two-drags-(TR_to_BL_then_BL_to_TR)"
+    );
+  });
+
+  it("Select via method", function (): void {
+    cy.visRun(({ network }): void => {
+      network.setSelection({
+        nodes: ["N_1", "N_3"],
+        edges: ["E_1-2", "E_1-3", "E_1-4", "E_1-5", "E_3-4", "E_2-3"],
+      });
+    });
+
+    cy.visSnapshotOpenedPage("select-via-method");
   });
 });

--- a/lib/network/modules/SelectionHandler.js
+++ b/lib/network/modules/SelectionHandler.js
@@ -641,18 +641,18 @@ class SelectionHandler {
    * @param {object} options                                 Options
    */
   setSelection(selection, options = {}) {
-    let i, id;
+    if (!selection || (!selection.nodes && !selection.edges)) {
+      throw new TypeError(
+        "Selection must be an object with nodes and/or edges properties"
+      );
+    }
 
-    if (!selection || (!selection.nodes && !selection.edges))
-      throw "Selection must be an object with nodes and/or edges properties";
     // first unselect any selected node, if option is true or undefined
     if (options.unselectAll || options.unselectAll === undefined) {
       this.unselectAll();
     }
     if (selection.nodes) {
-      for (i = 0; i < selection.nodes.length; i++) {
-        id = selection.nodes[i];
-
+      for (const id of selection.nodes) {
         const node = this.body.nodes[id];
         if (!node) {
           throw new RangeError('Node with id "' + id + '" not found');
@@ -663,9 +663,7 @@ class SelectionHandler {
     }
 
     if (selection.edges) {
-      for (i = 0; i < selection.edges.length; i++) {
-        id = selection.edges[i];
-
+      for (const id of selection.edges) {
         const edge = this.body.edges[id];
         if (!edge) {
           throw new RangeError('Edge with id "' + id + '" not found');
@@ -674,6 +672,7 @@ class SelectionHandler {
       }
     }
     this.body.emitter.emit("_requestRedraw");
+    this._selectionAccumulator.commit();
   }
 
   /**


### PR DESCRIPTION
This was introduced by #1133, it was a simple matter of forgetting to commit the selection after making changes to it which resulted in the nodes not being highlighted as they should be. A visual regression test is included to test that the selection is rendered properly.

Closes #1135.