### PR TITLE
fix(groups): dedupe group names (+ some refactoring)

### DIFF
--- a/lib/network/Network.js
+++ b/lib/network/Network.js
@@ -14,7 +14,7 @@ import * as locales from "./locales";
 import { normalizeLanguageCode } from "./locale-utils";
 
 import Images from "./Images";
-import Groups from "./modules/Groups";
+import { Groups } from "./modules/Groups";
 import NodesHandler from "./modules/NodesHandler";
 import EdgesHandler from "./modules/EdgesHandler";
 import PhysicsEngine from "./modules/PhysicsEngine";

--- a/lib/network/modules/Groups.js
+++ b/lib/network/modules/Groups.js
@@ -1,17 +1,16 @@
 /**
  * This class can store groups and options specific for groups.
  */
-class Groups {
+export class Groups {
   /**
    * @ignore
    */
   constructor() {
     this.clear();
-    this.defaultIndex = 0;
-    this.groupsArray = [];
-    this.groupIndex = 0;
+    this._defaultIndex = 0;
+    this._groupIndex = 0;
 
-    this.defaultGroups = [
+    this._defaultGroups = [
       {
         border: "#2B7CE9",
         background: "#97C2FC",
@@ -167,8 +166,8 @@ class Groups {
    * Clear all groups
    */
   clear() {
-    this.groups = {};
-    this.groupsArray = [];
+    this._groups = new Map();
+    this._groupNames = [];
   }
 
   /**
@@ -180,26 +179,26 @@ class Groups {
    * @returns {object} The found or created group
    */
   get(groupname, shouldCreate = true) {
-    let group = this.groups[groupname];
+    let group = this._groups.get(groupname);
 
     if (group === undefined && shouldCreate) {
       if (
         this.options.useDefaultGroups === false &&
-        this.groupsArray.length > 0
+        this._groupNames.length > 0
       ) {
         // create new group
-        const index = this.groupIndex % this.groupsArray.length;
-        this.groupIndex++;
+        const index = this._groupIndex % this._groupNames.length;
+        ++this._groupIndex;
         group = {};
-        group.color = this.groups[this.groupsArray[index]];
-        this.groups[groupname] = group;
+        group.color = this._groups.get(this._groupNames[index]);
+        this._groups.set(groupname, group);
       } else {
         // create new group
-        const index = this.defaultIndex % this.defaultGroups.length;
-        this.defaultIndex++;
+        const index = this._defaultIndex % this._defaultGroups.length;
+        this._defaultIndex++;
         group = {};
-        group.color = this.defaultGroups[index];
-        this.groups[groupname] = group;
+        group.color = this._defaultGroups[index];
+        this._groups.set(groupname, group);
       }
     }
 
@@ -207,18 +206,23 @@ class Groups {
   }
 
   /**
-   * Add a custom group style
+   * Add custom group style.
    *
-   * @param {string} groupName
-   * @param {object} style       An object containing borderColor,
-   *                             backgroundColor, etc.
-   * @returns {object} group      The created group object
+   * @param {string} groupName - The name of the group, a new group will be
+   * created if a group with the same name doesn't exist, otherwise the old
+   * groups style will be overwritten.
+   * @param {object} style - An object containing borderColor, backgroundColor,
+   * etc.
+   * @returns {object} The created group object.
    */
   add(groupName, style) {
-    this.groups[groupName] = style;
-    this.groupsArray.push(groupName);
+    // Only push group name once to prevent duplicates which would consume more
+    // RAM and also skew the distribution towards more often updated groups,
+    // neither of which is desirable.
+    if (!this._groups.has(groupName)) {
+      this._groupNames.push(groupName);
+    }
+    this._groups.set(groupName, style);
     return style;
   }
 }
-
-export default Groups;


### PR DESCRIPTION
Deduping group names saves negligible amount of memory and makes all groups equally likely to be selected as new group templates.

Regardings refactoring, properties not accessed from the outside were renamed with leading underscore to mark them as private. Default export was converted to named export. Map is used instead of object for key (name) value (style) storage of groups.

Closes #1170.