### PR TITLE
Fix typo in docs code (Importing data from Gephi)

### DIFF
--- a/docs/network/index.html
+++ b/docs/network/index.html
@@ -2721,7 +2721,7 @@ var parsed = vis.parseGephiNetwork(gephiJSON, parserOptions);
 // provide data in the normal fashion
 var data = {
   nodes: parsed.nodes,
-  edged: parsed.edges
+  edges: parsed.edges
 };
 
 // create a network


### PR DESCRIPTION
Hi !
Just a small correction of an error in the documentation for importing data from a JSON Gephi.

Before:
![image](https://user-images.githubusercontent.com/3446172/99106551-b129a600-25e4-11eb-8a40-7f733f2c9e15.png)

After:
![image](https://user-images.githubusercontent.com/3446172/99106579-bf77c200-25e4-11eb-9e61-4dd728675735.png)

