### PR TITLE
refactor(cypress): remove redundant code

### DIFF
--- a/cypress/pages/standard-cytest-script.ts
+++ b/cypress/pages/standard-cytest-script.ts
@@ -160,8 +160,6 @@ type VisUtil = typeof visUtil;
     names: readonly (string | number)[],
     content: string | number
   ): void => {
-    names = Array.isArray(names) ? names : [names];
-
     const elem = document.createElement("pre");
     elem.classList.add(...names.map((value): string => "" + value));
     elem.innerText = "" + content;


### PR DESCRIPTION
Given the types this did absolutely nothing, the only case when it would do something (i.e. convert `string | number` to `[string | number]`) would be reported by TS as an error if used.