### PR TITLE
fix(a11y): solve some issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ of the project.
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Network</title>
     <script

--- a/cypress/pages/events-target.html
+++ b/cypress/pages/events-target.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Cypress | Events Target</title>
 

--- a/cypress/pages/pollution.html
+++ b/cypress/pages/pollution.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Cypress | Pollution</title>
 

--- a/cypress/pages/universal.html
+++ b/cypress/pages/universal.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Cypress | Universal</title>
 

--- a/docs-kr/index.html
+++ b/docs-kr/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="ko">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="refresh" content="0;url=network/" />

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="refresh" content="0;url=network/" />

--- a/examples/network/basicUsage.html
+++ b/examples/network/basicUsage.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Basic usage</title>
 

--- a/examples/network/basic_usage/esnext.html
+++ b/examples/network/basic_usage/esnext.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>Network | Basic Usage | ESNext Build</title>

--- a/examples/network/basic_usage/legacy.html
+++ b/examples/network/basic_usage/legacy.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>Network | Basic Usage | Legacy Build</title>

--- a/examples/network/basic_usage/peer.html
+++ b/examples/network/basic_usage/peer.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>Network | Basic Usage | Peer Build</title>

--- a/examples/network/basic_usage/standalone.html
+++ b/examples/network/basic_usage/standalone.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>Network | Basic Usage | Standalone Build</title>

--- a/examples/network/data/datasets.html
+++ b/examples/network/data/datasets.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Data | Dynamic Data</title>
 

--- a/examples/network/data/dotLanguage/dotEdgeStyles.html
+++ b/examples/network/data/dotLanguage/dotEdgeStyles.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Data | DOT edge styles</title>
 

--- a/examples/network/data/dotLanguage/dotLanguage.html
+++ b/examples/network/data/dotLanguage/dotLanguage.html
@@ -1,4 +1,5 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <title>Vis Network | Data | DOT Language</title>
 

--- a/examples/network/data/dotLanguage/dotPlayground.html
+++ b/examples/network/data/dotLanguage/dotPlayground.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Data | DOT language playground</title>
 

--- a/examples/network/data/dynamicData.html
+++ b/examples/network/data/dynamicData.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Data | DataSet</title>
 

--- a/examples/network/data/dynamicFiltering.html
+++ b/examples/network/data/dynamicFiltering.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Data | Dynamic filtering</title>
 

--- a/examples/network/data/importingFromGephi.html
+++ b/examples/network/data/importingFromGephi.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- saved from url=(0044)http://kenedict.com/networks/worldcup14/vis/ , thanks Andre!-->
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF8" />
     <title>Vis Network | Data | Importing from Gephi (JSON)</title>

--- a/examples/network/data/scalingCustom.html
+++ b/examples/network/data/scalingCustom.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Data | Custom Scaling</title>
 

--- a/examples/network/data/scalingNodesEdges.html
+++ b/examples/network/data/scalingNodesEdges.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Data | Scaling Nodes and Edges</title>
 

--- a/examples/network/data/scalingNodesEdgesLabels.html
+++ b/examples/network/data/scalingNodesEdgesLabels.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Data | Scaling Labels</title>
 

--- a/examples/network/edgeStyles/arrowAlignment.html
+++ b/examples/network/edgeStyles/arrowAlignment.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Edge Styles | Arrow Alignment</title>
 

--- a/examples/network/edgeStyles/arrowTypes.html
+++ b/examples/network/edgeStyles/arrowTypes.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Edge Styles | Arrow Types</title>
 

--- a/examples/network/edgeStyles/arrows.html
+++ b/examples/network/edgeStyles/arrows.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Edge Styles | Arrows</title>
 

--- a/examples/network/edgeStyles/background.html
+++ b/examples/network/edgeStyles/background.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Edge Styles | Edge background</title>
 

--- a/examples/network/edgeStyles/colors.html
+++ b/examples/network/edgeStyles/colors.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Edge Styles | Colors</title>
 

--- a/examples/network/edgeStyles/dashes.html
+++ b/examples/network/edgeStyles/dashes.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Edge Styles | Dashes</title>
 

--- a/examples/network/edgeStyles/endPointOffsets.html
+++ b/examples/network/edgeStyles/endPointOffsets.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Edge Styles | Endpoint Offsets</title>
 

--- a/examples/network/edgeStyles/imageArrowHeads.html
+++ b/examples/network/edgeStyles/imageArrowHeads.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>Vis Network | Edge Styles | Image Arrow Heads</title>

--- a/examples/network/edgeStyles/selfReference.html
+++ b/examples/network/edgeStyles/selfReference.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Edge Styles | Self Reference</title>
 

--- a/examples/network/edgeStyles/smooth.html
+++ b/examples/network/edgeStyles/smooth.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Edge Styles | Static smooth curves</title>
 

--- a/examples/network/edgeStyles/smoothWorldCup.html
+++ b/examples/network/edgeStyles/smoothWorldCup.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- saved from url=(0044)http://kenedict.com/networks/worldcup14/vis/ , thanks Andre!-->
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF8" />
     <title>

--- a/examples/network/events/interactionEvents.html
+++ b/examples/network/events/interactionEvents.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Events | Interaction events</title>
 

--- a/examples/network/events/physicsEvents.html
+++ b/examples/network/events/physicsEvents.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Events | Physics Events</title>
 

--- a/examples/network/events/renderEvents.html
+++ b/examples/network/events/renderEvents.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Events | Rendering Events</title>
 

--- a/examples/network/exampleApplications/disassemblerExample.html
+++ b/examples/network/exampleApplications/disassemblerExample.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Example Applications | Disassembler</title>
     <style type="text/css">

--- a/examples/network/exampleApplications/lesMiserables.html
+++ b/examples/network/exampleApplications/lesMiserables.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Example Applications | Les miserables</title>
 

--- a/examples/network/exampleApplications/loadingBar.html
+++ b/examples/network/exampleApplications/loadingBar.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Example Applications | Loading Bar</title>
 

--- a/examples/network/exampleApplications/neighbourhoodHighlight.html
+++ b/examples/network/exampleApplications/neighbourhoodHighlight.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- saved from url=(0044)http://kenedict.com/networks/worldcup14/vis/ , thanks Andre!-->
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF8" />
     <title>

--- a/examples/network/exampleApplications/nodeLegend.html
+++ b/examples/network/exampleApplications/nodeLegend.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- saved from url=(0046)http://visjs.org/examples/network/03_images.html -->
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
     <title>Vis Network | Example Applications | Node Legend</title>

--- a/examples/network/exampleApplications/worldCupPerformance.html
+++ b/examples/network/exampleApplications/worldCupPerformance.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- saved from url=(0044)http://kenedict.com/networks/worldcup14/vis/ , thanks Andre!-->
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF8" />
     <title>Vis Network | Example Applications | World Cup Network</title>

--- a/examples/network/imageSelected/imageSelected.html
+++ b/examples/network/imageSelected/imageSelected.html
@@ -1,4 +1,5 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <title>Vis Network | Node Styles | Selected/Unselected Image</title>
 

--- a/examples/network/labels/labelAlignment.html
+++ b/examples/network/labels/labelAlignment.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Labels | Label Alignment</title>
 

--- a/examples/network/labels/labelBackground.html
+++ b/examples/network/labels/labelBackground.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Labels | Label Background</title>
 

--- a/examples/network/labels/labelColorAndSize.html
+++ b/examples/network/labels/labelColorAndSize.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Labels | Label Color and Size</title>
 

--- a/examples/network/labels/labelMargins.html
+++ b/examples/network/labels/labelMargins.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Labels | Label Margins</title>
 

--- a/examples/network/labels/labelMultifont.html
+++ b/examples/network/labels/labelMultifont.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Labels | Multifont Labels</title>
 

--- a/examples/network/labels/labelStroke.html
+++ b/examples/network/labels/labelStroke.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Labels | Label stroke</title>
 

--- a/examples/network/labels/multilineText.html
+++ b/examples/network/labels/multilineText.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Labels | Multiline text</title>
 

--- a/examples/network/layout/hierarchicalLayout.html
+++ b/examples/network/layout/hierarchicalLayout.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Layouts | Hierarchical Layout</title>
 

--- a/examples/network/layout/hierarchicalLayoutBigUserDefined.html
+++ b/examples/network/layout/hierarchicalLayoutBigUserDefined.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>
       Vis Network | Layouts | User Defined Hierarchical Layout (Big)

--- a/examples/network/layout/hierarchicalLayoutDynamicChanges.html
+++ b/examples/network/layout/hierarchicalLayoutDynamicChanges.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Layouts | Dynamic Hierarchical Layout Changes</title>
 

--- a/examples/network/layout/hierarchicalLayoutMethods.html
+++ b/examples/network/layout/hierarchicalLayoutMethods.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Layouts | Hierarchical Layout Methods</title>
 

--- a/examples/network/layout/hierarchicalLayoutOverlapAvoidance.html
+++ b/examples/network/layout/hierarchicalLayoutOverlapAvoidance.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Layouts | Hierarchical Layout Overlap Avoidance</title>
 

--- a/examples/network/layout/hierarchicalLayoutUserdefined.html
+++ b/examples/network/layout/hierarchicalLayoutUserdefined.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>
       Vis Network | Layouts | User Defined Hierarchical Layout (Configurable)

--- a/examples/network/layout/hierarchicalLayoutWithoutPhysics.html
+++ b/examples/network/layout/hierarchicalLayoutWithoutPhysics.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>Vis Network | Layouts | Hierarchical Layout without Physics</title>

--- a/examples/network/layout/randomSeed.html
+++ b/examples/network/layout/randomSeed.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Layouts | Setting the Random Seed</title>
 

--- a/examples/network/nodeStyles/HTMLInNodes.html
+++ b/examples/network/nodeStyles/HTMLInNodes.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Node Styles | HTML in Nodes</title>
 

--- a/examples/network/nodeStyles/circularImages.html
+++ b/examples/network/nodeStyles/circularImages.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Node Styles | Circular Images</title>
 

--- a/examples/network/nodeStyles/colors.html
+++ b/examples/network/nodeStyles/colors.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Node Styles | Colors</title>
 

--- a/examples/network/nodeStyles/customGroups.html
+++ b/examples/network/nodeStyles/customGroups.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Node Styles | Custom Groups</title>
 

--- a/examples/network/nodeStyles/groups.html
+++ b/examples/network/nodeStyles/groups.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Node Styles | Groups</title>
 

--- a/examples/network/nodeStyles/images.html
+++ b/examples/network/nodeStyles/images.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Node Styles | Images</title>
 

--- a/examples/network/nodeStyles/imagesWithBorders.html
+++ b/examples/network/nodeStyles/imagesWithBorders.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Node Styles | Images with Borders</title>
 

--- a/examples/network/nodeStyles/imagesWithBordersAndPadding.html
+++ b/examples/network/nodeStyles/imagesWithBordersAndPadding.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>
       Vis Network | Node Styles | Images with Borders and Image Padding

--- a/examples/network/nodeStyles/imagesWithCoordinateOrigin.html
+++ b/examples/network/nodeStyles/imagesWithCoordinateOrigin.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>
       Vis Network | Node Styles | Images with alternative coordinate origin

--- a/examples/network/nodeStyles/imagesWithOpacity.html
+++ b/examples/network/nodeStyles/imagesWithOpacity.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Node Styles | Images with Opacity</title>
 

--- a/examples/network/nodeStyles/overwriteGroups.html
+++ b/examples/network/nodeStyles/overwriteGroups.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Node Styles | Overriding Group Styles</title>
 

--- a/examples/network/nodeStyles/shadows.html
+++ b/examples/network/nodeStyles/shadows.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Node Styles | Shadows</title>
 

--- a/examples/network/nodeStyles/shapes.html
+++ b/examples/network/nodeStyles/shapes.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Node Styles | Shapes</title>
 

--- a/examples/network/nodeStyles/shapesWithDashedBorders.html
+++ b/examples/network/nodeStyles/shapesWithDashedBorders.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Node Styles | Shapes with Dashed Borders</title>
 

--- a/examples/network/nodeStyles/widthHeight.html
+++ b/examples/network/nodeStyles/widthHeight.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Node Styles | Label Width and Height Settings</title>
 

--- a/examples/network/other/animationShowcase.html
+++ b/examples/network/other/animationShowcase.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Other | Animations</title>
 

--- a/examples/network/other/automaticResizing.html
+++ b/examples/network/other/automaticResizing.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Other | Automatic Resizing</title>
 

--- a/examples/network/other/changingClusteredEdgesNodes.html
+++ b/examples/network/other/changingClusteredEdgesNodes.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Other | Changing Clustered Edges and Nodes</title>
 

--- a/examples/network/other/chosen.html
+++ b/examples/network/other/chosen.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Other | Chosen Elements</title>
 

--- a/examples/network/other/clustering.html
+++ b/examples/network/other/clustering.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Other | Clustering</title>
 

--- a/examples/network/other/clusteringByZoom.html
+++ b/examples/network/other/clusteringByZoom.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Other | Clustering by Zoom Level</title>
 

--- a/examples/network/other/configuration.html
+++ b/examples/network/other/configuration.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Other | Playing with Physics</title>
 

--- a/examples/network/other/cursorChange.html
+++ b/examples/network/other/cursorChange.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Other | Cursor Change</title>
 
@@ -77,7 +77,7 @@
       &nbsp;
 
       <button
-        onClick="changeEventCursor(document.getElementById('eventType').value,document.getElementById('cursorType').value);"
+        onclick="changeEventCursor(document.getElementById('eventType').value,document.getElementById('cursorType').value);"
       >
         Change Cursor for Event
       </button>

--- a/examples/network/other/manipulation.html
+++ b/examples/network/other/manipulation.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>Vis Network | Manipulation | Manipulation with Localization</title>
@@ -104,6 +104,7 @@
         var options = {
           layout: { randomSeed: seed }, // just to make sure the layout is the same when the locale is changed
           locale: document.getElementById("locale").value,
+          interaction: { keyboard: true },
           manipulation: {
             addNode: function (data, callback) {
               // filling in the popup DOM elements

--- a/examples/network/other/manipulationEditEdgeNoDrag.html
+++ b/examples/network/other/manipulationEditEdgeNoDrag.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>Vis Network | Manipulation | Edit Edge Without Drag</title>

--- a/examples/network/other/navigation.html
+++ b/examples/network/other/navigation.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Other | Navigation</title>
 

--- a/examples/network/other/onLoadAnimation.html
+++ b/examples/network/other/onLoadAnimation.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>Vis Network | Other | On Load Animation</title>
@@ -42,7 +42,7 @@
         <option value="easeInOutQuint">easeInOutQuint</option>
       </select>
       <button
-        onClick="createNetwork(document.getElementById('easingFunction').value);"
+        onclick="createNetwork(document.getElementById('easingFunction').value);"
       >
         Demo Easing Function
       </button>

--- a/examples/network/other/performance.html
+++ b/examples/network/other/performance.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Other | Performance</title>
 

--- a/examples/network/other/saveAndLoad.html
+++ b/examples/network/other/saveAndLoad.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
     <meta content="utf-8" http-equiv="encoding" />

--- a/examples/network/physics/physicsConfiguration.html
+++ b/examples/network/physics/physicsConfiguration.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Physics | Playing with Physics</title>
 

--- a/examples/network/physics/wind.html
+++ b/examples/network/physics/wind.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Vis Network | Physics | Wind</title>
 

--- a/examples/network/tests/hidden_edge_test.html
+++ b/examples/network/tests/hidden_edge_test.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>Vis Network | Tests | Hidden Edge Test</title>

--- a/examples/network/version_migration/5.4.1_to_6.0.0/manipulationEditEdgeNoDrag.html
+++ b/examples/network/version_migration/5.4.1_to_6.0.0/manipulationEditEdgeNoDrag.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>Vis Network</title>

--- a/lib/network/locales.ts
+++ b/lib/network/locales.ts
@@ -3,6 +3,7 @@ export interface Locale {
   addEdge: string;
   addNode: string;
   back: string;
+  close: string;
   createEdgeError: string;
   del: string;
   deleteClusterError: string;
@@ -21,6 +22,7 @@ export const en: Locale = {
   addEdge: "Add Edge",
   addNode: "Add Node",
   back: "Back",
+  close: "Close",
   createEdgeError: "Cannot link edges to a cluster.",
   del: "Delete selected",
   deleteClusterError: "Clusters cannot be deleted.",
@@ -41,6 +43,7 @@ export const de: Locale = {
   addEdge: "Kante hinzuf\u00fcgen",
   addNode: "Knoten hinzuf\u00fcgen",
   back: "Zur\u00fcck",
+  close: "Schließen",
   createEdgeError:
     "Es ist nicht m\u00f6glich, Kanten mit Clustern zu verbinden.",
   del: "L\u00f6sche Auswahl",
@@ -62,6 +65,7 @@ export const es: Locale = {
   addEdge: "A\u00f1adir arista",
   addNode: "A\u00f1adir nodo",
   back: "Atr\u00e1s",
+  close: "Cerrar",
   createEdgeError: "No se puede conectar una arista a un grupo.",
   del: "Eliminar selecci\u00f3n",
   deleteClusterError: "No es posible eliminar grupos.",
@@ -81,6 +85,7 @@ export const it: Locale = {
   addEdge: "Aggiungi un vertice",
   addNode: "Aggiungi un nodo",
   back: "Indietro",
+  close: "Chiudere",
   createEdgeError: "Non si possono collegare vertici ad un cluster",
   del: "Cancella la selezione",
   deleteClusterError: "I cluster non possono essere cancellati",
@@ -100,6 +105,7 @@ export const nl: Locale = {
   addEdge: "Link toevoegen",
   addNode: "Node toevoegen",
   back: "Terug",
+  close: "Sluiten",
   createEdgeError: "Kan geen link maken naar een cluster.",
   del: "Selectie verwijderen",
   deleteClusterError: "Clusters kunnen niet worden verwijderd.",
@@ -119,6 +125,7 @@ export const pt: Locale = {
   addEdge: "Adicionar aresta",
   addNode: "Adicionar nó",
   back: "Voltar",
+  close: "Fechar",
   createEdgeError: "Não foi possível linkar arestas a um cluster.",
   del: "Remover selecionado",
   deleteClusterError: "Clusters não puderam ser removidos.",
@@ -138,6 +145,7 @@ export const ru: Locale = {
   addEdge: "Добавить ребро",
   addNode: "Добавить узел",
   back: "Назад",
+  close: "Закрывать",
   createEdgeError: "Невозможно соединить ребра в кластер.",
   del: "Удалить выбранное",
   deleteClusterError: "Кластеры не могут быть удалены",
@@ -157,6 +165,7 @@ export const cn: Locale = {
   addEdge: "添加连接线",
   addNode: "添加节点",
   back: "返回",
+  close: "關閉",
   createEdgeError: "无法将连接线连接到群集。",
   del: "删除选定",
   deleteClusterError: "无法删除群集。",
@@ -174,6 +183,7 @@ export const uk: Locale = {
   addEdge: "Додати край",
   addNode: "Додати вузол",
   back: "Назад",
+  close: "Закрити",
   createEdgeError: "Не можливо об'єднати краї в групу.",
   del: "Видалити обране",
   deleteClusterError: "Групи не можуть бути видалені.",
@@ -193,6 +203,7 @@ export const fr: Locale = {
   addEdge: "Ajouter un lien",
   addNode: "Ajouter un nœud",
   back: "Retour",
+  close: "Fermer",
   createEdgeError: "Impossible de créer un lien vers un cluster.",
   del: "Effacer la sélection",
   deleteClusterError: "Les clusters ne peuvent pas être effacés.",
@@ -212,6 +223,7 @@ export const cs: Locale = {
   addEdge: "Přidat hranu",
   addNode: "Přidat vrchol",
   back: "Zpět",
+  close: "Zavřít",
   createEdgeError: "Nelze připojit hranu ke shluku.",
   del: "Smazat výběr",
   deleteClusterError: "Nelze mazat shluky.",

--- a/lib/network/modules/Canvas.js
+++ b/lib/network/modules/Canvas.js
@@ -232,7 +232,7 @@ class Canvas {
     this.frame.className = "vis-network";
     this.frame.style.position = "relative";
     this.frame.style.overflow = "hidden";
-    this.frame.tabIndex = 900; // tab index is required for keycharm to bind keystrokes to the div instead of the window
+    this.frame.tabIndex = 0; // tab index is required for keycharm to bind keystrokes to the div instead of the window
 
     //////////////////////////////////////////////////////////////////
 

--- a/lib/network/modules/ManipulationSystem.css
+++ b/lib/network/modules/ManipulationSystem.css
@@ -60,7 +60,8 @@ div.vis-network div.vis-manipulation {
   height: 28px;
 }
 
-div.vis-network div.vis-edit-mode {
+div.vis-network div.vis-edit-mode,
+div.vis-network button.vis-edit-mode {
   position: absolute;
   left: 0;
   top: 5px;
@@ -69,16 +70,18 @@ div.vis-network div.vis-edit-mode {
 
 /* FIXME: shouldn't the vis-close button be a child of the vis-manipulation div? */
 
-div.vis-network div.vis-close {
+div.vis-network button.vis-close {
   position: absolute;
   right: 0;
   top: 0;
   width: 30px;
   height: 30px;
 
+  background-color: transparent;
   background-position: 20px 3px;
   background-repeat: no-repeat;
   background-image: inline("cross.png");
+  border: none;
   cursor: pointer;
   -webkit-touch-callout: none;
   -webkit-user-select: none;
@@ -88,23 +91,24 @@ div.vis-network div.vis-close {
   user-select: none;
 }
 
-div.vis-network div.vis-close:hover {
+div.vis-network button.vis-close:hover {
   opacity: 0.6;
 }
 
-div.vis-network div.vis-manipulation div.vis-button,
-div.vis-network div.vis-edit-mode div.vis-button {
+div.vis-network div.vis-manipulation button.vis-button,
+div.vis-network div.vis-edit-mode button.vis-button {
   float: left;
   font-family: verdana;
   font-size: 12px;
+  border: none;
+  box-sizing: content-box;
   -moz-border-radius: 15px;
   border-radius: 15px;
-  display: inline-block;
+  background-color: transparent;
   background-position: 0px 0px;
   background-repeat: no-repeat;
   height: 24px;
   margin-left: 10px;
-  /*vertical-align:middle;*/
   cursor: pointer;
   padding: 0px 8px 0px 8px;
   -webkit-touch-callout: none;
@@ -115,52 +119,53 @@ div.vis-network div.vis-edit-mode div.vis-button {
   user-select: none;
 }
 
-div.vis-network div.vis-manipulation div.vis-button:hover {
+div.vis-network div.vis-manipulation button.vis-button:hover {
   box-shadow: 1px 1px 8px rgba(0, 0, 0, 0.2);
 }
 
-div.vis-network div.vis-manipulation div.vis-button:active {
+div.vis-network div.vis-manipulation button.vis-button:active {
   box-shadow: 1px 1px 8px rgba(0, 0, 0, 0.5);
 }
 
-div.vis-network div.vis-manipulation div.vis-button.vis-back {
+div.vis-network div.vis-manipulation button.vis-button.vis-back {
   background-image: inline("backIcon.png");
 }
 
-div.vis-network div.vis-manipulation div.vis-button.vis-none:hover {
+div.vis-network div.vis-manipulation div.vis-none:hover {
   box-shadow: 1px 1px 8px rgba(0, 0, 0, 0);
   cursor: default;
 }
-div.vis-network div.vis-manipulation div.vis-button.vis-none:active {
+div.vis-network div.vis-manipulation div.vis-none:active {
   box-shadow: 1px 1px 8px rgba(0, 0, 0, 0);
 }
-div.vis-network div.vis-manipulation div.vis-button.vis-none {
-  padding: 0;
+div.vis-network div.vis-manipulation div.vis-none {
+  padding: 0px;
+  line-height: 23px;
 }
 div.vis-network div.vis-manipulation div.notification {
   margin: 2px;
   font-weight: bold;
 }
 
-div.vis-network div.vis-manipulation div.vis-button.vis-add {
+div.vis-network div.vis-manipulation button.vis-button.vis-add {
   background-image: inline("addNodeIcon.png");
 }
 
-div.vis-network div.vis-manipulation div.vis-button.vis-edit,
-div.vis-network div.vis-edit-mode div.vis-button.vis-edit {
+div.vis-network div.vis-manipulation button.vis-button.vis-edit,
+div.vis-network div.vis-edit-mode button.vis-button.vis-edit {
   background-image: inline("editIcon.png");
 }
 
-div.vis-network div.vis-edit-mode div.vis-button.vis-edit.vis-edit-mode {
+div.vis-network div.vis-edit-mode button.vis-button.vis-edit.vis-edit-mode {
   background-color: #fcfcfc;
   border: 1px solid #cccccc;
 }
 
-div.vis-network div.vis-manipulation div.vis-button.vis-connect {
+div.vis-network div.vis-manipulation button.vis-button.vis-connect {
   background-image: inline("connectIcon.png");
 }
 
-div.vis-network div.vis-manipulation div.vis-button.vis-delete {
+div.vis-network div.vis-manipulation button.vis-button.vis-delete {
   background-image: inline("deleteIcon.png");
 }
 /* top right bottom left */

--- a/lib/network/modules/ManipulationSystem.js
+++ b/lib/network/modules/ManipulationSystem.js
@@ -28,7 +28,7 @@ class ManipulationSystem {
     this.editModeDiv = undefined;
     this.closeDiv = undefined;
 
-    this.manipulationHammers = [];
+    this._domEventListenerCleanupQueue = [];
     this.temporaryUIFunctions = {};
     this.temporaryEventFunctions = [];
 
@@ -242,7 +242,7 @@ class ManipulationSystem {
       }
 
       // bind the close button
-      this._bindHammerToDiv(this.closeDiv, this.toggleEditMode.bind(this));
+      this._bindElementEvents(this.closeDiv, this.toggleEditMode.bind(this));
 
       // refresh this bar based on what has been selected
       this._temporaryBindEvent(
@@ -278,7 +278,7 @@ class ManipulationSystem {
       );
 
       // bind the close button
-      this._bindHammerToDiv(this.closeDiv, this.toggleEditMode.bind(this));
+      this._bindElementEvents(this.closeDiv, this.toggleEditMode.bind(this));
     }
 
     this._temporaryBindEvent("click", this._performAddNode.bind(this));
@@ -361,7 +361,7 @@ class ManipulationSystem {
       );
 
       // bind the close button
-      this._bindHammerToDiv(this.closeDiv, this.toggleEditMode.bind(this));
+      this._bindElementEvents(this.closeDiv, this.toggleEditMode.bind(this));
     }
 
     // temporarily overload functions
@@ -408,7 +408,7 @@ class ManipulationSystem {
       );
 
       // bind the close button
-      this._bindHammerToDiv(this.closeDiv, this.toggleEditMode.bind(this));
+      this._bindElementEvents(this.closeDiv, this.toggleEditMode.bind(this));
     }
 
     this.edgeBeingEditedId = this.selectionHandler.getSelectedEdgeIds()[0];
@@ -585,8 +585,13 @@ class ManipulationSystem {
 
     // container for the close div button
     if (this.closeDiv === undefined) {
-      this.closeDiv = document.createElement("div");
+      this.closeDiv = document.createElement("button");
       this.closeDiv.className = "vis-close";
+      this.closeDiv.setAttribute(
+        "aria-label",
+        this.options.locales[this.options.locale]?.["close"] ??
+          this.options.locales["en"]["close"]
+      );
       this.closeDiv.style.display = this.manipulationDiv.style.display;
       this.canvas.frame.appendChild(this.closeDiv);
     }
@@ -633,13 +638,13 @@ class ManipulationSystem {
     const locale = this.options.locales[this.options.locale];
     const button = this._createButton(
       "editMode",
-      "vis-button vis-edit vis-edit-mode",
+      "vis-edit vis-edit-mode",
       locale["edit"] || this.options.locales["en"]["edit"]
     );
     this.editModeDiv.appendChild(button);
 
     // bind a hammer listener to the button, calling the function toggleEditMode.
-    this._bindHammerToDiv(button, this.toggleEditMode.bind(this));
+    this._bindElementEvents(button, this.toggleEditMode.bind(this));
   }
 
   /**
@@ -657,7 +662,7 @@ class ManipulationSystem {
       recursiveDOMDelete(this.manipulationDiv);
 
       // removes all the bindings and overloads
-      this._cleanManipulatorHammers();
+      this._cleanupDOMEventListeners();
     }
 
     // remove temporary nodes and edges
@@ -678,13 +683,10 @@ class ManipulationSystem {
    *
    * @private
    */
-  _cleanManipulatorHammers() {
-    // _clean hammer bindings
-    if (this.manipulationHammers.length != 0) {
-      for (let i = 0; i < this.manipulationHammers.length; i++) {
-        this.manipulationHammers[i].destroy();
-      }
-      this.manipulationHammers = [];
+  _cleanupDOMEventListeners() {
+    // _clean DOM event listener bindings
+    for (const callback of this._domEventListenerCleanupQueue.splice(0)) {
+      callback();
     }
   }
 
@@ -746,11 +748,11 @@ class ManipulationSystem {
   _createAddNodeButton(locale) {
     const button = this._createButton(
       "addNode",
-      "vis-button vis-add",
+      "vis-add",
       locale["addNode"] || this.options.locales["en"]["addNode"]
     );
     this.manipulationDiv.appendChild(button);
-    this._bindHammerToDiv(button, this.addNodeMode.bind(this));
+    this._bindElementEvents(button, this.addNodeMode.bind(this));
   }
 
   /**
@@ -761,11 +763,11 @@ class ManipulationSystem {
   _createAddEdgeButton(locale) {
     const button = this._createButton(
       "addEdge",
-      "vis-button vis-connect",
+      "vis-connect",
       locale["addEdge"] || this.options.locales["en"]["addEdge"]
     );
     this.manipulationDiv.appendChild(button);
-    this._bindHammerToDiv(button, this.addEdgeMode.bind(this));
+    this._bindElementEvents(button, this.addEdgeMode.bind(this));
   }
 
   /**
@@ -776,11 +778,11 @@ class ManipulationSystem {
   _createEditNodeButton(locale) {
     const button = this._createButton(
       "editNode",
-      "vis-button vis-edit",
+      "vis-edit",
       locale["editNode"] || this.options.locales["en"]["editNode"]
     );
     this.manipulationDiv.appendChild(button);
-    this._bindHammerToDiv(button, this.editNode.bind(this));
+    this._bindElementEvents(button, this.editNode.bind(this));
   }
 
   /**
@@ -791,11 +793,11 @@ class ManipulationSystem {
   _createEditEdgeButton(locale) {
     const button = this._createButton(
       "editEdge",
-      "vis-button vis-edit",
+      "vis-edit",
       locale["editEdge"] || this.options.locales["en"]["editEdge"]
     );
     this.manipulationDiv.appendChild(button);
-    this._bindHammerToDiv(button, this.editEdgeMode.bind(this));
+    this._bindElementEvents(button, this.editEdgeMode.bind(this));
   }
 
   /**
@@ -806,9 +808,9 @@ class ManipulationSystem {
   _createDeleteButton(locale) {
     let deleteBtnClass;
     if (this.options.rtl) {
-      deleteBtnClass = "vis-button vis-delete-rtl";
+      deleteBtnClass = "vis-delete-rtl";
     } else {
-      deleteBtnClass = "vis-button vis-delete";
+      deleteBtnClass = "vis-delete";
     }
     const button = this._createButton(
       "delete",
@@ -816,7 +818,7 @@ class ManipulationSystem {
       locale["del"] || this.options.locales["en"]["del"]
     );
     this.manipulationDiv.appendChild(button);
-    this._bindHammerToDiv(button, this.deleteSelected.bind(this));
+    this._bindElementEvents(button, this.deleteSelected.bind(this));
   }
 
   /**
@@ -827,11 +829,11 @@ class ManipulationSystem {
   _createBackButton(locale) {
     const button = this._createButton(
       "back",
-      "vis-button vis-back",
+      "vis-back",
       locale["back"] || this.options.locales["en"]["back"]
     );
     this.manipulationDiv.appendChild(button);
-    this._bindHammerToDiv(button, this.showManipulatorToolbar.bind(this));
+    this._bindElementEvents(button, this.showManipulatorToolbar.bind(this));
   }
 
   /**
@@ -844,8 +846,8 @@ class ManipulationSystem {
    * @private
    */
   _createButton(id, className, label, labelClassName = "vis-label") {
-    this.manipulationDOM[id + "Div"] = document.createElement("div");
-    this.manipulationDOM[id + "Div"].className = className;
+    this.manipulationDOM[id + "Div"] = document.createElement("button");
+    this.manipulationDOM[id + "Div"].className = "vis-button " + className;
     this.manipulationDOM[id + "Label"] = document.createElement("div");
     this.manipulationDOM[id + "Label"].className = labelClassName;
     this.manipulationDOM[id + "Label"].innerHTML = label;
@@ -861,9 +863,10 @@ class ManipulationSystem {
    * @private
    */
   _createDescription(label) {
-    this.manipulationDiv.appendChild(
-      this._createButton("description", "vis-button vis-none", label)
-    );
+    this.manipulationDOM["descriptionLabel"] = document.createElement("div");
+    this.manipulationDOM["descriptionLabel"].className = "vis-none";
+    this.manipulationDOM["descriptionLabel"].innerHTML = label;
+    this.manipulationDiv.appendChild(this.manipulationDOM["descriptionLabel"]);
   }
 
   // -------------------------- End of DOM functions for buttons ------------------------------//
@@ -948,10 +951,24 @@ class ManipulationSystem {
    * @param {Element} domElement
    * @param {Function} boundFunction
    */
-  _bindHammerToDiv(domElement, boundFunction) {
+  _bindElementEvents(domElement, boundFunction) {
+    // Bind touch events.
     const hammer = new Hammer(domElement, {});
     onTouch(hammer, boundFunction);
-    this.manipulationHammers.push(hammer);
+    this._domEventListenerCleanupQueue.push(() => {
+      hammer.destroy();
+    });
+
+    // Bind keyboard events.
+    const keyupListener = ({ keyCode, key }) => {
+      if (key === "Enter" || key === " " || keyCode === 13 || keyCode === 32) {
+        boundFunction();
+      }
+    };
+    domElement.addEventListener("keyup", keyupListener, false);
+    this._domEventListenerCleanupQueue.push(() => {
+      domElement.removeEventListener("keyup", keyupListener, false);
+    });
   }
 
   /**

--- a/test/network/maximumWidthEdgeCase.html
+++ b/test/network/maximumWidthEdgeCase.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Maximum Width Edge Case Test</title>
 

--- a/test/network/textMeasurementOnHoverTest.html
+++ b/test/network/textMeasurementOnHoverTest.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Text Measurement Test</title>
 

--- a/test/networkTest.html
+++ b/test/networkTest.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>JS Bin</title>

--- a/test/network_unittests.html
+++ b/test/network_unittests.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-<html>
-  <head lang="en">
+<html lang="en">
+  <head>
     <meta charset="UTF-8" />
     <title></title>
 


### PR DESCRIPTION
- Tabindex on the network element is 0 now.
- All pages now declare their language.
- Manipulation buttons are buttons now.
- Manipulation buttons are tabbable now.
- Manipulation buttons can be triggered by the keyboard (enter, space).
- Manipulation close button has aria label (I speak only 3 languages of the 11 I translated, there may be errors.).

Most of the stuff was just about ignoring accessibility (I'm sure there still is a lot to improve.) but one thing that stands out is the tabindex attribute on the network element (as reported by #1238). I wonder why it was set to 900. No matter how I think about it, 900 just seems nonsensical to me (also, pretty arbitrary value). The only thing it achieves is bizarre tabbing behavior (It would be focused as the first thing in the page no matter where it's placed, unless something has positive tabindex of 899 or less.).

This PR will change how tabbing works in pages using Vis Network. However I can't imagine why would anyone want it the old way. From my perspective, Vis Network used to mess up tabbing order and now it doesn't. We may discuss this further though, as there may be situations where this could be considered a breaking change, I just don't see any.

Closes #1238.