### PR TITLE
fix(xss): don't use innerHTML to set plain text or wrap text into an element

### DIFF
--- a/cypress/pages/pollution.html
+++ b/cypress/pages/pollution.html
@@ -70,7 +70,9 @@
           );
 
           const root = document.getElementById(id);
-          root.innerText = "";
+          while (root.firstChild) {
+            root.removeChild(root.firstChild);
+          }
 
           const table = document.createElement("table");
           ["added", "changed", "missing"].forEach((key) => {

--- a/docs-kr/network/index.html
+++ b/docs-kr/network/index.html
@@ -68,12 +68,12 @@
     <script>
       function toggleGettingStarted(aThis) {
         var gettingStartedDiv = document.getElementById("gettingStarted");
-        if (aThis.innerHTML.indexOf("Show") !== -1) {
+        if (aThis.innerText.indexOf("Show") !== -1) {
           gettingStartedDiv.className = "";
-          aThis.innerHTML = "Hide the getting started again.";
+          aThis.innerText = "Hide the getting started again.";
         } else {
           gettingStartedDiv.className = "hidden";
-          aThis.innerHTML = "Show the getting started!";
+          aThis.innerText = "Show the getting started!";
         }
       }
     </script>

--- a/docs/network/index.html
+++ b/docs/network/index.html
@@ -68,12 +68,12 @@
     <script>
       function toggleGettingStarted(aThis) {
         var gettingStartedDiv = document.getElementById("gettingStarted");
-        if (aThis.innerHTML.indexOf("Show") !== -1) {
+        if (aThis.innerText.indexOf("Show") !== -1) {
           gettingStartedDiv.className = "";
-          aThis.innerHTML = "Hide the getting started again.";
+          aThis.innerText = "Hide the getting started again.";
         } else {
           gettingStartedDiv.className = "hidden";
-          aThis.innerHTML = "Show the getting started!";
+          aThis.innerText = "Show the getting started!";
         }
       }
     </script>

--- a/examples/network/data/dynamicData.html
+++ b/examples/network/data/dynamicData.html
@@ -130,7 +130,7 @@
         // create an array with nodes
         nodes = new vis.DataSet();
         nodes.on("*", function () {
-          document.getElementById("nodes").innerHTML = JSON.stringify(
+          document.getElementById("nodes").innerText = JSON.stringify(
             nodes.get(),
             null,
             4
@@ -147,7 +147,7 @@
         // create an array with edges
         edges = new vis.DataSet();
         edges.on("*", function () {
-          document.getElementById("edges").innerHTML = JSON.stringify(
+          document.getElementById("edges").innerText = JSON.stringify(
             edges.get(),
             null,
             4

--- a/examples/network/data/importingFromGephi.html
+++ b/examples/network/data/importingFromGephi.html
@@ -149,7 +149,7 @@
       network.on("click", function (params) {
         if (params.nodes.length > 0) {
           var data = nodes.get(params.nodes[0]); // get the data from selected node
-          nodeContent.innerHTML = JSON.stringify(data, undefined, 3); // show the data in the div
+          nodeContent.innerText = JSON.stringify(data, undefined, 3); // show the data in the div
         }
       });
 
@@ -179,7 +179,7 @@
         edges.add(parsed.edges);
 
         var data = nodes.get(2); // get the data from node 2 as example
-        nodeContent.innerHTML = JSON.stringify(data, undefined, 3); // show the data in the div
+        nodeContent.innerText = JSON.stringify(data, undefined, 3); // show the data in the div
         network.fit(); // zoom to fit
       }
     </script>

--- a/examples/network/edgeStyles/arrowTypes.html
+++ b/examples/network/edgeStyles/arrowTypes.html
@@ -39,12 +39,18 @@
 
       // update list of arrow types in html body
       var nof_types = arrow_types.length;
-      var list_contents = [];
-      for (var i = 0; i < nof_types; i++) {
-        list_contents.push("<code>'" + arrow_types[i] + "'</code>");
-      }
       var mylist = document.getElementById("arrow_type_list");
-      mylist.innerHTML = list_contents.join(", ");
+      while (mylist.firstChild) {
+        mylist.removeChild(mylist.firstChild);
+      }
+      for (var i = 0; i < nof_types; i++) {
+        if (i > 0) {
+          mylist.appendChild(document.createTextNode(", "));
+        }
+        const code = document.createElement("code");
+        code.innerText = arrow_types[i];
+        mylist.appendChild(code);
+      }
 
       // create an array with nodes
       var node_attrs = new Array();

--- a/examples/network/events/interactionEvents.html
+++ b/examples/network/events/interactionEvents.html
@@ -23,7 +23,9 @@
     </p>
 
     <div id="mynetwork"></div>
-    <pre id="eventSpan"></pre>
+
+    <h2 id="eventSpanHeading"></h2>
+    <pre id="eventSpanContent"></pre>
 
     <script type="text/javascript">
       // create an array with nodes
@@ -61,8 +63,12 @@
 
       network.on("click", function (params) {
         params.event = "[original event]";
-        document.getElementById("eventSpan").innerHTML =
-          "<h2>Click event:</h2>" + JSON.stringify(params, null, 4);
+        document.getElementById("eventSpanHeading").innerText = "Click event:";
+        document.getElementById("eventSpanContent").innerText = JSON.stringify(
+          params,
+          null,
+          4
+        );
         console.log(
           "click event, getNodeAt returns: " +
             this.getNodeAt(params.pointer.DOM)
@@ -70,14 +76,23 @@
       });
       network.on("doubleClick", function (params) {
         params.event = "[original event]";
-        document.getElementById("eventSpan").innerHTML =
-          "<h2>doubleClick event:</h2>" + JSON.stringify(params, null, 4);
+        document.getElementById("eventSpanHeading").innerText =
+          "doubleClick event:";
+        document.getElementById("eventSpanContent").innerText = JSON.stringify(
+          params,
+          null,
+          4
+        );
       });
       network.on("oncontext", function (params) {
         params.event = "[original event]";
-        document.getElementById("eventSpan").innerHTML =
-          "<h2>oncontext (right click) event:</h2>" +
-          JSON.stringify(params, null, 4);
+        document.getElementById("eventSpanHeading").innerText =
+          "oncontext (right click) event:";
+        document.getElementById("eventSpanContent").innerText = JSON.stringify(
+          params,
+          null,
+          4
+        );
       });
       network.on("dragStart", function (params) {
         // There's no point in displaying this event on screen, it gets immediately overwritten
@@ -90,13 +105,23 @@
       });
       network.on("dragging", function (params) {
         params.event = "[original event]";
-        document.getElementById("eventSpan").innerHTML =
-          "<h2>dragging event:</h2>" + JSON.stringify(params, null, 4);
+        document.getElementById("eventSpanHeading").innerText =
+          "dragging event:";
+        document.getElementById("eventSpanContent").innerText = JSON.stringify(
+          params,
+          null,
+          4
+        );
       });
       network.on("dragEnd", function (params) {
         params.event = "[original event]";
-        document.getElementById("eventSpan").innerHTML =
-          "<h2>dragEnd event:</h2>" + JSON.stringify(params, null, 4);
+        document.getElementById("eventSpanHeading").innerText =
+          "dragEnd event:";
+        document.getElementById("eventSpanContent").innerText = JSON.stringify(
+          params,
+          null,
+          4
+        );
         console.log("dragEnd Event:", params);
         console.log(
           "dragEnd event, getNodeAt returns: " +
@@ -105,24 +130,41 @@
       });
       network.on("controlNodeDragging", function (params) {
         params.event = "[original event]";
-        document.getElementById("eventSpan").innerHTML =
-          "<h2>control node dragging event:</h2>" +
-          JSON.stringify(params, null, 4);
+        document.getElementById("eventSpanHeading").innerText =
+          "control node dragging event:";
+        document.getElementById("eventSpanContent").innerText = JSON.stringify(
+          params,
+          null,
+          4
+        );
       });
       network.on("controlNodeDragEnd", function (params) {
         params.event = "[original event]";
-        document.getElementById("eventSpan").innerHTML =
-          "<h2>control node drag end event:</h2>" +
-          JSON.stringify(params, null, 4);
+        document.getElementById("eventSpanHeading").innerText =
+          "control node drag end event:";
+        document.getElementById("eventSpanContent").innerText = JSON.stringify(
+          params,
+          null,
+          4
+        );
         console.log("controlNodeDragEnd Event:", params);
       });
       network.on("zoom", function (params) {
-        document.getElementById("eventSpan").innerHTML =
-          "<h2>zoom event:</h2>" + JSON.stringify(params, null, 4);
+        document.getElementById("eventSpanHeading").innerText = "zoom event:";
+        document.getElementById("eventSpanContent").innerText = JSON.stringify(
+          params,
+          null,
+          4
+        );
       });
       network.on("showPopup", function (params) {
-        document.getElementById("eventSpan").innerHTML =
-          "<h2>showPopup event: </h2>" + JSON.stringify(params, null, 4);
+        document.getElementById("eventSpanHeading").innerText =
+          "showPopup event: ";
+        document.getElementById("eventSpanContent").innerText = JSON.stringify(
+          params,
+          null,
+          4
+        );
       });
       network.on("hidePopup", function () {
         console.log("hidePopup Event");

--- a/examples/network/events/physicsEvents.html
+++ b/examples/network/events/physicsEvents.html
@@ -20,7 +20,10 @@
     <p>Create a simple network with some nodes and edges.</p>
 
     <div id="mynetwork"></div>
-    <pre id="eventSpan"></pre>
+
+    <h2 id="eventSpanHeading"></h2>
+    <pre id="eventSpanContent"></pre>
+
     <script type="text/javascript">
       // create an array with nodes
       var nodes = new vis.DataSet([
@@ -49,23 +52,34 @@
       var network = new vis.Network(container, data, options);
 
       network.on("startStabilizing", function (params) {
-        document.getElementById("eventSpan").innerHTML =
-          "<h3>Starting Stabilization</h3>";
+        document.getElementById("eventSpanHeading").innerText =
+          "Starting Stabilization";
+        document.getElementById("eventSpanContent").innerText = "";
         console.log("started");
       });
       network.on("stabilizationProgress", function (params) {
-        document.getElementById("eventSpan").innerHTML =
-          "<h3>Stabilization progress</h3>" + JSON.stringify(params, null, 4);
+        document.getElementById("eventSpanHeading").innerText =
+          "Stabilization progress";
+        document.getElementById("eventSpanContent").innerText = JSON.stringify(
+          params,
+          null,
+          4
+        );
         console.log("progress:", params);
       });
       network.on("stabilizationIterationsDone", function (params) {
-        document.getElementById("eventSpan").innerHTML =
-          "<h3>Stabilization iterations complete</h3>";
+        document.getElementById("eventSpanHeading").innerText =
+          "Stabilization iterations complete";
+        document.getElementById("eventSpanContent").innerText = "";
         console.log("finished stabilization interations");
       });
       network.on("stabilized", function (params) {
-        document.getElementById("eventSpan").innerHTML =
-          "<h3>Stabilized!</h3>" + JSON.stringify(params, null, 4);
+        document.getElementById("eventSpanHeading").innerText = "Stabilized!";
+        document.getElementById("eventSpanContent").innerText = JSON.stringify(
+          params,
+          null,
+          4
+        );
         console.log("stabilized!", params);
       });
     </script>

--- a/examples/network/exampleApplications/loadingBar.html
+++ b/examples/network/exampleApplications/loadingBar.html
@@ -498,11 +498,11 @@
           var width = Math.max(minWidth, maxWidth * widthFactor);
 
           document.getElementById("bar").style.width = width + "px";
-          document.getElementById("text").innerHTML =
+          document.getElementById("text").innerText =
             Math.round(widthFactor * 100) + "%";
         });
         network.once("stabilizationIterationsDone", function () {
-          document.getElementById("text").innerHTML = "100%";
+          document.getElementById("text").innerText = "100%";
           document.getElementById("bar").style.width = "496px";
           document.getElementById("loadingBar").style.opacity = 0;
           // really clean the dom element

--- a/examples/network/labels/labelAlignment.html
+++ b/examples/network/labels/labelAlignment.html
@@ -37,7 +37,9 @@
     </p>
 
     <div id="mynetwork"></div>
-    <pre id="eventSpan"></pre>
+
+    <h2 id="eventSpanHeading"></h2>
+    <pre id="eventSpanContent"></pre>
 
     <script type="text/javascript">
       // create an array with nodes
@@ -77,8 +79,12 @@
 
       network.on("click", function (params) {
         params.event = "[original event]";
-        document.getElementById("eventSpan").innerHTML =
-          "<h2>Click event:</h2>" + JSON.stringify(params, null, 4);
+        document.getElementById("eventSpanHeading").innerText = "Click event:";
+        document.getElementById("eventSpanContent").innerText = JSON.stringify(
+          params,
+          null,
+          4
+        );
       });
     </script>
   </body>

--- a/examples/network/layout/hierarchicalLayout.html
+++ b/examples/network/layout/hierarchicalLayout.html
@@ -58,7 +58,7 @@
 
         // add event listeners
         network.on("select", function (params) {
-          document.getElementById("selection").innerHTML =
+          document.getElementById("selection").innerText =
             "Selection: " + params.nodes;
         });
       }

--- a/examples/network/layout/hierarchicalLayoutOverlapAvoidance.html
+++ b/examples/network/layout/hierarchicalLayoutOverlapAvoidance.html
@@ -217,7 +217,7 @@
 
         // add event listeners
         network.on("select", function (params) {
-          document.getElementById("selection").innerHTML =
+          document.getElementById("selection").innerText =
             "Selection: " + params.nodes;
         });
       }

--- a/examples/network/layout/hierarchicalLayoutUserdefined.html
+++ b/examples/network/layout/hierarchicalLayoutUserdefined.html
@@ -103,7 +103,7 @@
 
         // add event listeners
         network.on("select", function (params) {
-          document.getElementById("selection").innerHTML =
+          document.getElementById("selection").innerText =
             "Selection: " + params.nodes;
         });
       }

--- a/examples/network/other/animationShowcase.html
+++ b/examples/network/other/animationShowcase.html
@@ -105,15 +105,15 @@
 
         // add event listeners
         network.on("select", function (params) {
-          document.getElementById("selection").innerHTML =
+          document.getElementById("selection").innerText =
             "Selection: " + params.nodes;
         });
         network.on("stabilized", function (params) {
-          document.getElementById("stabilization").innerHTML =
+          document.getElementById("stabilization").innerText =
             "Stabilization took " + params.iterations + " iterations.";
         });
         network.on("animationFinished", function () {
-          statusUpdateSpan.innerHTML = finishMessage;
+          statusUpdateSpan.innerText = finishMessage;
         });
       }
 
@@ -125,7 +125,7 @@
           duration: duration,
           easingFunction: easingFunction,
         };
-        statusUpdateSpan.innerHTML = "Doing fit() Animation.";
+        statusUpdateSpan.innerText = "Doing fit() Animation.";
         finishMessage = "Animation finished.";
         network.fit({ animation: options });
       }
@@ -139,7 +139,7 @@
           offset: { x: offsetx, y: offsety },
           animation: true, // default duration is 1000ms and default easingFunction is easeInOutQuad.
         };
-        statusUpdateSpan.innerHTML = "Doing Animation.";
+        statusUpdateSpan.innerText = "Doing Animation.";
         finishMessage = "Animation finished.";
         network.moveTo(options);
       }
@@ -156,7 +156,7 @@
             easingFunction: easingFunction,
           },
         };
-        statusUpdateSpan.innerHTML = "Doing Animation.";
+        statusUpdateSpan.innerText = "Doing Animation.";
         finishMessage = "Animation finished.";
         network.moveTo(options);
       }
@@ -174,7 +174,7 @@
             easingFunction: easingFunction,
           },
         };
-        statusUpdateSpan.innerHTML = "Focusing on node: " + nodeId;
+        statusUpdateSpan.innerText = "Focusing on node: " + nodeId;
         finishMessage = "Node: " + nodeId + " in focus.";
         network.focus(nodeId, options);
       }

--- a/examples/network/other/changingClusteredEdgesNodes.html
+++ b/examples/network/other/changingClusteredEdgesNodes.html
@@ -44,7 +44,9 @@
     </ul>
 
     <div id="mynetwork"></div>
-    <pre id="eventSpan"></pre>
+
+    <h2 id="eventSpanHeading"></h2>
+    <pre id="eventSpanContent"></pre>
 
     <script type="text/javascript">
       // create an array with nodes
@@ -130,8 +132,11 @@
           obj.all_clustered_edges = network.clustering.getClusteredEdges(
             params.edges[0]
           );
-          document.getElementById("eventSpan").innerHTML =
-            "<h2>selectEdge event:</h2>" + JSON.stringify(obj, null, 4);
+          document.getElementById("eventSpanHeading").innerText =
+            "selectEdge event:";
+          document.getElementById(
+            "eventSpanContent"
+          ).innerText = JSON.stringify(obj, null, 4);
         }
       });
     </script>

--- a/examples/network/other/manipulation.html
+++ b/examples/network/other/manipulation.html
@@ -108,7 +108,7 @@
           manipulation: {
             addNode: function (data, callback) {
               // filling in the popup DOM elements
-              document.getElementById("operation").innerHTML = "Add Node";
+              document.getElementById("operation").innerText = "Add Node";
               document.getElementById("node-id").value = data.id;
               document.getElementById("node-label").value = data.label;
               document.getElementById("saveButton").onclick = saveData.bind(
@@ -123,7 +123,7 @@
             },
             editNode: function (data, callback) {
               // filling in the popup DOM elements
-              document.getElementById("operation").innerHTML = "Edit Node";
+              document.getElementById("operation").innerText = "Edit Node";
               document.getElementById("node-id").value = data.id;
               document.getElementById("node-label").value = data.label;
               document.getElementById("saveButton").onclick = saveData.bind(

--- a/examples/network/other/manipulationEditEdgeNoDrag.html
+++ b/examples/network/other/manipulationEditEdgeNoDrag.html
@@ -122,12 +122,12 @@
           manipulation: {
             addNode: function (data, callback) {
               // filling in the popup DOM elements
-              document.getElementById("node-operation").innerHTML = "Add Node";
+              document.getElementById("node-operation").innerText = "Add Node";
               editNode(data, clearNodePopUp, callback);
             },
             editNode: function (data, callback) {
               // filling in the popup DOM elements
-              document.getElementById("node-operation").innerHTML = "Edit Node";
+              document.getElementById("node-operation").innerText = "Edit Node";
               editNode(data, cancelNodeEdit, callback);
             },
             addEdge: function (data, callback) {
@@ -138,12 +138,12 @@
                   return;
                 }
               }
-              document.getElementById("edge-operation").innerHTML = "Add Edge";
+              document.getElementById("edge-operation").innerText = "Add Edge";
               editEdgeWithoutDrag(data, callback);
             },
             editEdge: {
               editWithoutDrag: function (data, callback) {
-                document.getElementById("edge-operation").innerHTML =
+                document.getElementById("edge-operation").innerText =
                   "Edit Edge";
                 editEdgeWithoutDrag(data, callback);
               },

--- a/examples/network/other/navigation.html
+++ b/examples/network/other/navigation.html
@@ -86,7 +86,7 @@
 
         // add event listeners
         network.on("select", function (params) {
-          document.getElementById("selection").innerHTML =
+          document.getElementById("selection").innerText =
             "Selection: " + params.nodes;
         });
       }

--- a/examples/network/other/performance.html
+++ b/examples/network/other/performance.html
@@ -12,14 +12,6 @@
         height: 600px;
         border: 1px solid lightgray;
       }
-
-      #message {
-        color: darkred;
-        max-width: 600px;
-        font-size: 16px;
-        cursor: pointer;
-        text-decoration: underline;
-      }
     </style>
 
     <script
@@ -50,10 +42,15 @@
         destroy();
         var nodeCount = document.getElementById("nodeCount").value;
         if (nodeCount > 100) {
-          document.getElementById("message").innerHTML =
-            '<a onclick="disableSmoothCurves()">You may want to disable dynamic smooth curves for better performance with a large amount of nodes and edges. Click here to disable them.</a>';
+          document.getElementById("disable-smooth-curves").style.display =
+            "inline";
+          document.getElementById("enable-smooth-curves").style.display =
+            "none";
         } else if (setSmooth === false) {
-          document.getElementById("message").innerHTML = "";
+          document.getElementById("disable-smooth-curves").style.display =
+            "none";
+          document.getElementById("enable-smooth-curves").style.display =
+            "none";
         }
         // create a network
         var container = document.getElementById("mynetwork");
@@ -67,14 +64,16 @@
       function disableSmoothCurves() {
         setSmooth = true;
         network.setOptions({ edges: { smooth: { type: "continuous" } } });
-        document.getElementById("message").innerHTML =
-          '<a onclick="enableSmoothCurves()">Click here to reenable the dynamic smooth curves.</a>';
+        document.getElementById("disable-smooth-curves").style.display = "none";
+        document.getElementById("enable-smooth-curves").style.display =
+          "inline";
       }
 
       function enableSmoothCurves() {
         setSmooth = false;
-        document.getElementById("message").innerHTML =
-          '<a onclick="disableSmoothCurves()">You may want to disable dynamic smooth curves for better performance with a large amount of nodes and edges. Click here to disable them.</a>';
+        document.getElementById("disable-smooth-curves").style.display =
+          "inline";
+        document.getElementById("enable-smooth-curves").style.display = "none";
         network.setOptions({ edges: { smooth: { type: "dynamic" } } });
       }
     </script>
@@ -86,7 +85,25 @@
       <input id="nodeCount" type="text" value="25" style="width: 50px" />
       <input type="button" value="Go" onclick="draw()" />
     </form>
-    <span id="message"></span>
+
+    <a
+      id="disable-smooth-curves"
+      style="display: none"
+      href="#"
+      onclick="disableSmoothCurves()"
+    >
+      You may want to disable dynamic smooth curves for better performance with
+      a large amount of nodes and edges. Click here to disable them.
+    </a>
+    <a
+      id="enable-smooth-curves"
+      style="display: none"
+      href="#"
+      onclick="enableSmoothCurves()"
+    >
+      Click here to reenable the dynamic smooth curves.
+    </a>
+
     <div id="mynetwork"></div>
   </body>
 </html>

--- a/lib/network/modules/Canvas.js
+++ b/lib/network/modules/Canvas.js
@@ -245,7 +245,7 @@ class Canvas {
       noCanvas.style.color = "red";
       noCanvas.style.fontWeight = "bold";
       noCanvas.style.padding = "10px";
-      noCanvas.innerHTML = "Error: your browser does not support HTML canvas";
+      noCanvas.innerText = "Error: your browser does not support HTML canvas";
       this.frame.canvas.appendChild(noCanvas);
     } else {
       this._setPixelRatio();

--- a/lib/network/modules/ManipulationSystem.js
+++ b/lib/network/modules/ManipulationSystem.js
@@ -850,7 +850,7 @@ class ManipulationSystem {
     this.manipulationDOM[id + "Div"].className = "vis-button " + className;
     this.manipulationDOM[id + "Label"] = document.createElement("div");
     this.manipulationDOM[id + "Label"].className = labelClassName;
-    this.manipulationDOM[id + "Label"].innerHTML = label;
+    this.manipulationDOM[id + "Label"].innerText = label;
     this.manipulationDOM[id + "Div"].appendChild(
       this.manipulationDOM[id + "Label"]
     );
@@ -865,7 +865,7 @@ class ManipulationSystem {
   _createDescription(label) {
     this.manipulationDOM["descriptionLabel"] = document.createElement("div");
     this.manipulationDOM["descriptionLabel"].className = "vis-none";
-    this.manipulationDOM["descriptionLabel"].innerHTML = label;
+    this.manipulationDOM["descriptionLabel"].innerText = label;
     this.manipulationDiv.appendChild(this.manipulationDOM["descriptionLabel"]);
   }
 

--- a/lib/shared/ColorPicker.js
+++ b/lib/shared/ColorPicker.js
@@ -543,7 +543,7 @@ class ColorPicker {
       noCanvas.style.color = "red";
       noCanvas.style.fontWeight = "bold";
       noCanvas.style.padding = "10px";
-      noCanvas.innerHTML = "Error: your browser does not support HTML canvas";
+      noCanvas.innerText = "Error: your browser does not support HTML canvas";
       this.colorPickerCanvas.appendChild(noCanvas);
     } else {
       const ctx = this.colorPickerCanvas.getContext("2d");
@@ -612,38 +612,38 @@ class ColorPicker {
 
     this.brightnessLabel = document.createElement("div");
     this.brightnessLabel.className = "vis-label vis-brightness";
-    this.brightnessLabel.innerHTML = "brightness:";
+    this.brightnessLabel.innerText = "brightness:";
 
     this.opacityLabel = document.createElement("div");
     this.opacityLabel.className = "vis-label vis-opacity";
-    this.opacityLabel.innerHTML = "opacity:";
+    this.opacityLabel.innerText = "opacity:";
 
     this.newColorDiv = document.createElement("div");
     this.newColorDiv.className = "vis-new-color";
-    this.newColorDiv.innerHTML = "new";
+    this.newColorDiv.innerText = "new";
 
     this.initialColorDiv = document.createElement("div");
     this.initialColorDiv.className = "vis-initial-color";
-    this.initialColorDiv.innerHTML = "initial";
+    this.initialColorDiv.innerText = "initial";
 
     this.cancelButton = document.createElement("div");
     this.cancelButton.className = "vis-button vis-cancel";
-    this.cancelButton.innerHTML = "cancel";
+    this.cancelButton.innerText = "cancel";
     this.cancelButton.onclick = this._hide.bind(this, false);
 
     this.applyButton = document.createElement("div");
     this.applyButton.className = "vis-button vis-apply";
-    this.applyButton.innerHTML = "apply";
+    this.applyButton.innerText = "apply";
     this.applyButton.onclick = this._apply.bind(this);
 
     this.saveButton = document.createElement("div");
     this.saveButton.className = "vis-button vis-save";
-    this.saveButton.innerHTML = "save";
+    this.saveButton.innerText = "save";
     this.saveButton.onclick = this._save.bind(this);
 
     this.loadButton = document.createElement("div");
     this.loadButton.className = "vis-button vis-load";
-    this.loadButton.innerHTML = "load last";
+    this.loadButton.innerText = "load last";
     this.loadButton.onclick = this._loadLast.bind(this);
 
     this.frame.appendChild(this.colorPickerDiv);

--- a/lib/shared/Configurator.js
+++ b/lib/shared/Configurator.js
@@ -5,6 +5,25 @@ import { copyAndExtendArray } from "vis-util/esnext";
 import ColorPicker from "./ColorPicker";
 
 /**
+ * Wrap given text (last argument) in HTML elements (all preceding arguments).
+ *
+ * @param {...any} rest - List of tag names followed by inner text.
+ *
+ * @returns An element or a text node.
+ */
+function wrapInTag(...rest) {
+  if (rest.length < 1) {
+    throw new TypeError("Invalid arguments.");
+  } else if (rest.length === 1) {
+    return document.createTextNode(rest[0]);
+  } else {
+    const element = document.createElement(rest[0]);
+    element.appendChild(wrapInTag(rest.slice(1)));
+    return element;
+  }
+}
+
+/**
  * The way this works is for all properties of this.possible options, you can supply the property name in any form to list the options.
  * Boolean options are recognised as Boolean
  * Number options should be written as array: [default value, min value, max value, stepsize]
@@ -248,7 +267,7 @@ class Configurator {
   _makeHeader(name) {
     const div = document.createElement("div");
     div.className = "vis-configuration vis-config-header";
-    div.innerHTML = name;
+    div.innerText = name;
     this._makeItem([], div);
   }
 
@@ -266,9 +285,12 @@ class Configurator {
     div.className =
       "vis-configuration vis-config-label vis-config-s" + path.length;
     if (objectLabel === true) {
-      div.innerHTML = "<i><b>" + name + ":</b></i>";
+      while (div.firstChild) {
+        div.removeChild(div.firstChild);
+      }
+      div.appendChild(wrapInTag("i", "b", name));
     } else {
-      div.innerHTML = name + ":";
+      div.innerText = name + ":";
     }
     return div;
   }
@@ -297,7 +319,7 @@ class Configurator {
       if (i === selectedValue) {
         option.selected = "selected";
       }
-      option.innerHTML = arr[i];
+      option.innerText = arr[i];
       select.appendChild(option);
     }
 
@@ -391,7 +413,7 @@ class Configurator {
     if (this.options.showButton === true) {
       const generateButton = document.createElement("div");
       generateButton.className = "vis-configuration vis-config-button";
-      generateButton.innerHTML = "generate options";
+      generateButton.innerText = "generate options";
       generateButton.onclick = () => {
         this._printOptions();
       };
@@ -427,7 +449,7 @@ class Configurator {
       const div = document.createElement("div");
       div.id = "vis-configuration-popup";
       div.className = "vis-configuration-popup";
-      div.innerHTML = string;
+      div.innerText = string;
       div.onclick = () => {
         this._removePopup();
       };
@@ -762,8 +784,13 @@ class Configurator {
    */
   _printOptions() {
     const options = this.getOptions();
-    this.optionsContainer.innerHTML =
-      "<pre>var options = " + JSON.stringify(options, null, 2) + "</pre>";
+
+    while (this.optionsContainer.firstChild) {
+      this.optionsContainer.removeChild(this.optionsContainer.firstChild);
+    }
+    this.optionsContainer.appendChild(
+      wrapInTag("pre", "const options = " + JSON.stringify(options, null, 2))
+    );
   }
 
   /**

--- a/lib/shared/Popup.js
+++ b/lib/shared/Popup.js
@@ -39,7 +39,9 @@ class Popup {
    */
   setText(content) {
     if (content instanceof Element) {
-      this.frame.innerHTML = "";
+      while (this.frame.firstChild) {
+        this.frame.removeChild(this.frame.firstChild);
+      }
       this.frame.appendChild(content);
     } else {
       this.frame.innerHTML = content; // string containing text or HTML


### PR DESCRIPTION
We had a lot of instances of innerHTML that were simply setting text, in quite a few cases parsing it as HTML was even counter productive as it could theoretically result in syntax errors and corrupted output (e.g. the output of JSON.stringify definitely shouldn't be parsed as HTML).

There is only one occurrence of innerHTML left and that is for the node/edge title as the docs clearly state that any string passed will be parsed as HTML.