### PR TITLE
refactor(activator): various changes

### DIFF
--- a/lib/shared/Activator.js
+++ b/lib/shared/Activator.js
@@ -1,9 +1,7 @@
 import "./Activator.css";
 
-import keycharm from "keycharm";
 import Emitter from "component-emitter";
 import Hammer from "../module/hammer";
-import { addClassName, removeClassName } from "vis-util/esnext";
 
 /**
  * Turn an element into an clickToUse element.
@@ -17,19 +15,29 @@ import { addClassName, removeClassName } from "vis-util/esnext";
  * @class Activator
  */
 function Activator(container) {
+  this._cleanupQueue = [];
+
   this.active = false;
 
-  this.dom = {
-    container: container,
+  this._dom = {
+    container,
+    overlay: document.createElement("div"),
   };
 
-  this.dom.overlay = document.createElement("div");
-  this.dom.overlay.className = "vis-overlay";
+  this._dom.overlay.classList.add("vis-overlay");
 
-  this.dom.container.appendChild(this.dom.overlay);
+  this._dom.container.appendChild(this._dom.overlay);
+  this._cleanupQueue.push(() => {
+    this._dom.overlay.parentNode.removeChild(this._dom.overlay);
+  });
 
-  this.hammer = Hammer(this.dom.overlay);
-  this.hammer.on("tap", this._onTapOverlay.bind(this));
+  const hammer = Hammer(this._dom.overlay);
+  hammer.on("tap", this._onTapOverlay.bind(this));
+  this._cleanupQueue.push(() => {
+    hammer.destroy();
+    // FIXME: cleaning up hammer instances doesn't work (Timeline not removed
+    // from memory)
+  });
 
   // block all touch events (except tap)
   const events = [
@@ -43,28 +51,34 @@ function Activator(container) {
     "panend",
   ];
   events.forEach((event) => {
-    this.hammer.on(event, (event) => {
+    hammer.on(event, (event) => {
       event.srcEvent.stopPropagation();
     });
   });
 
   // attach a click event to the window, in order to deactivate when clicking outside the timeline
   if (document && document.body) {
-    this.onClick = (event) => {
+    this._onClick = (event) => {
       if (!_hasParent(event.target, container)) {
         this.deactivate();
       }
     };
-    document.body.addEventListener("click", this.onClick);
+    document.body.addEventListener("click", this._onClick);
+    this._cleanupQueue.push(() => {
+      document.body.removeEventListener("click", this._onClick);
+    });
   }
 
-  if (this.keycharm !== undefined) {
-    this.keycharm.destroy();
-  }
-  this.keycharm = keycharm();
-
-  // keycharm listener only bounded when active)
-  this.escListener = this.deactivate.bind(this);
+  // prepare escape key listener for deactivating when active
+  this._escListener = (event) => {
+    if (
+      "key" in event
+        ? event.key === "Escape"
+        : event.keyCode === 27 /* the keyCode is for IE11 */
+    ) {
+      this.deactivate();
+    }
+  };
 }
 
 // turn into an event emitter
@@ -79,22 +93,9 @@ Activator.current = null;
 Activator.prototype.destroy = function () {
   this.deactivate();
 
-  // remove dom
-  this.dom.overlay.parentNode.removeChild(this.dom.overlay);
-
-  // remove global event listener
-  if (this.onClick) {
-    document.body.removeEventListener("click", this.onClick);
+  for (const callback of this._cleanupQueue.splice(0).reverse()) {
+    callback();
   }
-  // remove keycharm
-  if (this.keycharm !== undefined) {
-    this.keycharm.destroy();
-  }
-  this.keycharm = null;
-  // cleanup hammer instances
-  this.hammer.destroy();
-  this.hammer = null;
-  // FIXME: cleaning up hammer instances doesn't work (Timeline not removed from memory)
 };
 
 /**
@@ -109,15 +110,15 @@ Activator.prototype.activate = function () {
   Activator.current = this;
 
   this.active = true;
-  this.dom.overlay.style.display = "none";
-  addClassName(this.dom.container, "vis-active");
+  this._dom.overlay.style.display = "none";
+  this._dom.container.classList.add("vis-active");
 
   this.emit("change");
   this.emit("activate");
 
   // ugly hack: bind ESC after emitting the events, as the Network rebinds all
   // keyboard events on a 'change' event
-  this.keycharm.bind("esc", this.escListener);
+  document.body.addEventListener("keydown", this._escListener);
 };
 
 /**
@@ -126,9 +127,9 @@ Activator.prototype.activate = function () {
  */
 Activator.prototype.deactivate = function () {
   this.active = false;
-  this.dom.overlay.style.display = "block";
-  removeClassName(this.dom.container, "vis-active");
-  this.keycharm.unbind("esc", this.escListener);
+  this._dom.overlay.style.display = "block";
+  this._dom.container.classList.remove("vis-active");
+  document.body.removeEventListener("keydown", this._escListener);
 
   this.emit("change");
   this.emit("deactivate");


### PR DESCRIPTION
This is mostly just to make it easier to move this into Vis Util. I especially wanted to get rid of Keycharm as it's used solely to (un)bind escape key listener and has basically zero added value in this code. This wouldn't really be a problem otherwise as Keycharm is also used elsewhere but it's not a dependency of Vis Util and for this single task it seems dumb to include it in Vis Util.

## Changes

Remove the dependency on Keycharm: All it really did was translate `"esc"` to `event.keyCode === 27` (which is deprecated by the way). We can just use `"key" in event ? event.key === "Escape" : event.keyCode === 27` instead of Keycharm and not rely solely on deprecated APIs.

Remove the use of `addClassName` and `removeClassName`: These basically polyfill IE9 and it's contemporaries (this is Windows Vista, iOS 4.3 and Android Gingerbread era) which we don't otherwise polyfill so they don't work one way or another.

Various other minor refactoring such as prefixing private properties with underscore.

None of this changes the way Activator works in any relevant way.