### PR TITLE
Edge labels with border and spacing

### DIFF
--- a/lib/network/modules/EdgesHandler.js
+++ b/lib/network/modules/EdgesHandler.js
@@ -56,6 +56,9 @@ class EdgesHandler {
         size: 14, // px
         face: "arial",
         background: "none",
+        borderColor: "none",
+        borderWidth: 0, // px
+        padding: 0, // px
         strokeWidth: 2, // px
         strokeColor: "#ffffff",
         align: "horizontal",

--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -59,6 +59,9 @@ class NodesHandler {
         size: 14, // px
         face: "arial",
         background: "none",
+        borderColor: "none",
+        borderWidth: 0, // px
+        padding: 0, // px
         strokeWidth: 0, // px
         strokeColor: "#ffffff",
         align: "center",

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -432,6 +432,7 @@ class Label {
     // update the size cache if required
     this.calculateLabelSize(ctx, selected, hover, x, y, baseline);
     this._drawBackground(ctx);
+    this._drawBorder(ctx);
     this._drawText(ctx, x, this.size.yLine, baseline, viewFontSize);
   }
 
@@ -447,9 +448,53 @@ class Label {
       this.fontOptions.background !== "none"
     ) {
       ctx.fillStyle = this.fontOptions.background;
-      const size = this.getSize();
+      const size = this._getSizeWithSpacing();
       ctx.fillRect(size.left, size.top, size.width, size.height);
     }
+  }
+
+  /**
+   * Draws the label border
+   *
+   * @param {CanvasRenderingContext2D} ctx
+   * @private
+   */
+  _drawBorder(ctx) {
+    if (
+      this.fontOptions.borderColor !== undefined &&
+      this.fontOptions.borderColor !== "none"
+    ) {
+      ctx.lineWidth = 1;
+      if (
+        this.fontOptions.borderWidth !== undefined &&
+        this.fontOptions.borderWidth !== "none"
+      ) {
+        ctx.lineWidth = this.fontOptions.borderWidth;
+      }
+      ctx.strokeStyle = this.fontOptions.borderColor;
+      const size = this._getSizeWithSpacing();
+      ctx.strokeRect(size.left, size.top, size.width, size.height);
+    }
+  }
+
+  /**
+   * Gets label's size with specified padding.
+   *
+   * @returns {number} Label's size.
+   * @private
+   */
+  _getSizeWithSpacing() {
+    const size = this.getSize();
+    if (
+      this.fontOptions.padding !== undefined &&
+      this.fontOptions.padding !== "none"
+    ) {
+      size.left -= this.fontOptions.padding;
+      size.top -= this.fontOptions.padding;
+      size.width += 2 * this.fontOptions.padding;
+      size.height += 2 * this.fontOptions.padding;
+    }
+    return size;
   }
 
   /**

--- a/lib/network/options.ts
+++ b/lib/network/options.ts
@@ -72,6 +72,9 @@ const nodeOptions: OptionsConfig = {
     size: { number }, // px
     face: { string },
     background: { string },
+    borderColor: { string },
+    borderWidth: { number }, // px
+    padding: { number },  // px
     strokeWidth: { number }, // px
     strokeColor: { string },
     vadjust: { number },
@@ -292,6 +295,9 @@ const allOptions: OptionsConfig = {
       size: { number }, // px
       face: { string },
       background: { string },
+      borderColor: { string },
+      borderWidth: { number }, // px
+      padding: { number },  // px
       strokeWidth: { number }, // px
       strokeColor: { string },
       align: { string: ["horizontal", "top", "middle", "bottom"] },
@@ -598,6 +604,9 @@ const configureOptions: ConfiguratorConfig = {
       size: [14, 0, 100, 1], // px
       face: ["arial", "verdana", "tahoma"],
       background: ["color", "none"],
+      borderColor: ["color", "none"],
+      borderWidth: [0, 0, 10, 1], // px
+      padding: [0, 0, 10, 1], // px
       strokeWidth: [0, 0, 50, 1], // px
       strokeColor: ["color", "#ffffff"],
     },
@@ -676,6 +685,9 @@ const configureOptions: ConfiguratorConfig = {
       size: [14, 0, 100, 1], // px
       face: ["arial", "verdana", "tahoma"],
       background: ["color", "none"],
+      borderColor: ["color", "none"],
+      borderWidth: [0, 0, 10, 1], // px
+      padding: [0, 0, 10, 1], // px
       strokeWidth: [2, 0, 50, 1], // px
       strokeColor: ["color", "#ffffff"],
       align: ["horizontal", "top", "middle", "bottom"],


### PR DESCRIPTION
I found some time to work on #535. With `font.borderColor`, `font.borderWidth` and `font.padding` options, it is possible to add a border and space to the label. Unfortunatly, I didn't take care of the border radius.

I also don't know it this is the right way to do this but I tried it and it works.
Let me know if something is wrong and needs to be corrected!
