### PR TITLE
fix(clustering): remove edge related to the cluster

### DIFF
--- a/lib/network/modules/Clustering.js
+++ b/lib/network/modules/Clustering.js
@@ -1459,13 +1459,6 @@ class ClusterEngine {
       delete this.clusteredEdges[edgeId];
     });
 
-    // Remove cluster edges from active list (this.body.edges).
-    // deletedEdgeIds still contains id of regular edges, but these should all
-    // be gone when you reach here.
-    forEach(deletedEdgeIds, (edgeId) => {
-      delete this.body.edges[edgeId];
-    });
-
     //
     // Check changed cluster state of edges
     //
@@ -1505,6 +1498,13 @@ class ClusterEngine {
         // undo clustering for this edge here.
         // throw new Error('remove edge from clustering not implemented!')
       }
+    });
+
+    // Remove cluster edges from active list (this.body.edges).
+    // deletedEdgeIds still contains id of regular edges, but these should all
+    // be gone when you reach here.
+    forEach(deletedEdgeIds, (edgeId) => {
+      delete this.body.edges[edgeId];
     });
 
     // Clusters may be nested to any level. Keep on opening until nothing to open


### PR DESCRIPTION
The PR has the purpose of fixing an issue, that I have discovered. I have tried to explain it inside the following issue #1373.

The issue happened when we attach an edge to a node inside a cluster. If we remove the edge, she is not properly removed from the cluster. If we adding again the relationship isn't shown on the graph.
