### PR TITLE
Improving the look of the start and example page in docs

### DIFF
--- a/examples/examples.css
+++ b/examples/examples.css
@@ -1,5 +1,4 @@
 .examples-root {
-  margin: 50px auto 200px;
   min-width: calc(200px + 2em);
   width: calc(100vw - 200px);
 }

--- a/examples/index.html
+++ b/examples/index.html
@@ -7,10 +7,39 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <link rel="stylesheet" type="text/css" href="examples.css" />
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/Tipue-Search/5.0.0/tipuesearch.css" rel="stylesheet"/>
+    <link href="../common-docs-files/css/style.css" rel="stylesheet"/>
+    <link href="../docs/css/overrides.css" rel="stylesheet"/>
+    <style>
+
+      div.full {
+        min-height: 50vh;
+        padding-bottom: 80px;
+      }
+    </style>
   </head>
   <body>
-    <div class="examples-root">
+  <div class="navbar-wrapper">
+    <div class="container">
+      <nav class="navbar-inverse navbar-static-top" role="navigation">
+        <div class="container">
+          <div class="navbar-header">
+
+            <a class="navbar-brand " href="./index.html">vis.js</a>
+          </div>
+          <div id="navbar" class="navbar-collapse collapse">
+            <ul class="nav navbar-nav"></ul>
+
+
+          </div>
+        </div>
+      </nav>
+    </div>
+  </div>
+    <div class="container full examples-root">
       <div>
+        <div id="breadcrumbs"><a href="../">vis-network</a><a href="./">examples</a></div>
         <h1>Vis Network</h1>
         <div>
           <span class="example-link"

--- a/index.html
+++ b/index.html
@@ -1,64 +1,82 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta name="description" content=""/>
+    <meta name="author" content=""/>
     <title>Vis Network</title>
-
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/Tipue-Search/5.0.0/tipuesearch.css" rel="stylesheet"/>
+    <link href="common-docs-files/css/style.css" rel="stylesheet"/>
+    <link href="docs/css/overrides.css" rel="stylesheet"/>
     <style>
-      .docs td:nth-child(1) {
-        text-align: right;
-      }
-      .docs td:nth-child(1) img {
-        border: 1px solid #000000;
-        height: 1em;
-        vertical-align: middle;
-      }
+
+
+        div.full {
+            min-height: 50vh;
+            padding-bottom: 80px;
+        }
     </style>
-  </head>
+</head>
+<body>
+<div class="navbar-wrapper">
+    <div class="container">
+        <nav class="navbar-inverse navbar-static-top" role="navigation">
+            <div class="container">
+                <div class="navbar-header">
 
-  <body>
-    <ul>
-      <li><a href="./coverage/lcov-report/">Coverage</a></li>
+                    <a class="navbar-brand " href="./index.html">vis.js</a>
+                </div>
+                <div id="navbar" class="navbar-collapse collapse">
+                    <ul class="nav navbar-nav"></ul>
 
-      <li>
-        Documentation:
-        <table class="docs">
-          <tr>
-            <td>
-              <a href="./docs/network/">
-                <img src="./common-docs-files/img/flags/en.svg" />
-              </a>
-            </td>
-            <td>
-              <a href="./docs/network/">English</a>
-            </td>
-          </tr>
 
-          <tr>
-            <td>
-              <a href="./docs-kr/network/">
-                <img src="./common-docs-files/img/flags/kr.svg" />
-              </a>
-            </td>
-            <td>
-              <a href="./docs-kr/network/">Korean</a>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://ame.cool/core/frontend-tools/">
-                <img src="./common-docs-files/img/flags/zh.svg" />
-              </a>
-            </td>
-            <td>
-              <a href="https://ame.cool/core/frontend-tools/">Chinese</a>
-              <sup> (third party) </sup>
-            </td>
-          </tr>
-        </table>
-      </li>
+                </div>
+            </div>
+        </nav>
+    </div>
+</div>
+<div class="container full">
+    <div id="breadcrumbs"><a href="./">vis-network</a></div>
 
-      <li><a href="./examples/">Examples</a></li>
-    </ul>
-  </body>
+    <h1>vis-network</h1>
+
+    <p>Network is a visualization to display networks and networks consisting of nodes and edges. The visualization is
+        easy to use and supports custom shapes, styles, colors, sizes, images, and more. The network visualization works
+        smooth on any modern browser for up to a few thousand nodes and edges. To handle a larger amount of nodes,
+        Network has clustering support. Network uses HTML canvas for rendering.
+    </p>
+
+    <p>
+        네트워크는 Node와 가장자리로 구성된 네트워크와 네트워크를 표시하기 위한 시각화다. 시각화는 사용하기 쉽고 사용자 지정 모양, 스타일, 색상, 크기, 이미지 등을 지원한다. 네트워크 시각화는 현대
+        브라우저에서 최대 수천 개의 Node와 Edge에 대해 원활하게 작동한다. 더 많은 Node를 처리하기 위해, 네트워크에는 클러스터링 지원이 있다. 네트워크는 렌더링을 위해 HTML 캔버스를 사용한다.
+    </p>
+
+
+    <a class="btn btn-primary btn-lg" href="./examples/">See Examples</a>
+
+    <h2>Documentation</h2>
+
+
+    <a href="./docs/network/" class="btn btn-default btn-lg">
+        <img src="./common-docs-files/img/flags/en.svg" height="30"/>
+        English</a>
+
+
+    <a href="./docs-kr/network/" class="btn btn-default btn-lg">
+        <img src="./common-docs-files/img/flags/kr.svg" height="30"/>
+        Korean</a>
+
+    <a href="https://ame.cool/core/frontend-tools/" class="btn btn-default btn-lg">
+        <img src="./common-docs-files/img/flags/zh.svg" height="30"/>
+        Chinese <small> (third party) </small></a>
+
+
+</div>
+
+
+</body>
 </html>


### PR DESCRIPTION
I've added some styling from the docs to the start and example page so it looks and feels like it's the same website.

You can see the changes here: https://nahakiole.github.io/vis-network/ and here https://nahakiole.github.io/vis-network/examples/ on my fork.

In the contribution guide it's written that the pull request should be made to the gh-pages branch, but here in the checklist of the pull request it's only the master branch?

https://github.com/visjs/vis-network/blob/master/misc/how_to_help.md
> The visjs.org webpage is hosted on the gh-pages branch. If you find a typo or anything else that should be improved feel free to create a pull-request to gh-pages. Please make changes in your own fork of gh-pages so the support team can view the changes in your hosted fork.

>  All pull requests must be to the [master branch](https://github.com/visjs/vis-network). Pull requests to any other branch will be closed!

If I need to move the commit to the other branch please tell me, and then I'll add a commit to update the how_to_help.md as well.

