### PR TITLE
Fix custom shape size

### DIFF
--- a/docs-kr/network/nodes.html
+++ b/docs-kr/network/nodes.html
@@ -279,6 +279,7 @@ var options = {
       coordinateOrigin: 'center'  // only for image and circularImage shapes
     }
     size: 25,
+    touchPadding: 0,
     title: undefined,
     value: undefined,
     widthConstraint: false,
@@ -1493,6 +1494,14 @@ mySize = minSize + diff * scale;
             <code>diamond</code>, <code>dot</code>, <code>star</code>,
             <code>triangle</code>, <code>triangleDown</code>,
             <code>hexagon</code>, <code>square</code>, <code>icon</code>
+          </td>
+        </tr>
+        <tr>
+          <td>touchPadding</td>
+          <td>Number</td>
+          <td><code>0</code></td>
+          <td>
+            실제 모양 치수보다 더 큰 터치 영역을 허용하는 데 사용됩니다.
           </td>
         </tr>
         <tr>

--- a/docs/network/nodes.html
+++ b/docs/network/nodes.html
@@ -280,6 +280,7 @@ var options = {
       coordinateOrigin: 'center'  // only for image and circularImage shapes
     }
     size: 25,
+    touchPadding: 0,
     title: undefined,
     value: undefined,
     widthConstraint: false,
@@ -1613,6 +1614,14 @@ mySize = minSize + diff * scale;
             <code>circularImage</code>, <code>diamond</code>, <code>dot</code>,
             <code>star</code>, <code>triangle</code>, <code>triangleDown</code>,
             <code>hexagon</code>, <code>square</code> and <code>icon</code>
+          </td>
+        </tr>
+        <tr>
+          <td>touchPadding</td>
+          <td>Number</td>
+          <td><code>0</code></td>
+          <td>
+            Used to allow a bigger touch area than the actual shape dimensions.
           </td>
         </tr>
         <tr>

--- a/docs/network/nodes.html
+++ b/docs/network/nodes.html
@@ -596,7 +596,7 @@ network.setOptions(options);
           <td>
             <p>The function inputs and outputs look like:</p>
             <pre class="code">
-function ctxRenderer({ ctx, id, x, y, state: { selected, hover }, style, label }) {
+function ctxRenderer({ ctx, id, x, y, state: { selected, hover }, style, label, options }) {
   // do some math here
   return {
     // bellow arrows

--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -143,6 +143,7 @@ class NodesHandler {
         coordinateOrigin: "center", // only for image and circularImage shapes
       },
       size: 25,
+      touchPadding: 0,
       title: undefined,
       value: undefined,
       x: undefined,

--- a/lib/network/modules/components/Node.js
+++ b/lib/network/modules/components/Node.js
@@ -801,11 +801,12 @@ class Node {
    * @returns {boolean}     True if location is located on node
    */
   isOverlappingWith(obj) {
+    const tp = this.options.touchPadding || 0;
     return (
-      this.shape.left < obj.right &&
-      this.shape.left + this.shape.width > obj.left &&
-      this.shape.top < obj.bottom &&
-      this.shape.top + this.shape.height > obj.top
+      this.shape.left - tp < obj.right &&
+      this.shape.left + this.shape.width + tp > obj.left &&
+      this.shape.top - tp < obj.bottom &&
+      this.shape.top + this.shape.height + tp > obj.top
     );
   }
 

--- a/lib/network/modules/components/nodes/shapes/CustomShape.js
+++ b/lib/network/modules/components/nodes/shapes/CustomShape.js
@@ -42,6 +42,7 @@ class CustomShape extends ShapeBase {
       state: { selected, hover },
       style: { ...values },
       label: this.options.label,
+      options: this.options,
     });
     // Render the node shape bellow arrows.
     if (drawLater.drawNode != null) {

--- a/lib/network/modules/components/nodes/shapes/CustomShape.js
+++ b/lib/network/modules/components/nodes/shapes/CustomShape.js
@@ -32,10 +32,6 @@ class CustomShape extends ShapeBase {
    * @returns {object} Callbacks to draw later on different layers.
    */
   draw(ctx, x, y, selected, hover, values) {
-    this.resize(ctx, selected, hover, values);
-    this.left = x - this.width / 2;
-    this.top = y - this.height / 2;
-
     // Guard right away because someone may just draw in the function itself.
     ctx.save();
     const drawLater = this.ctxRenderer({
@@ -67,6 +63,10 @@ class CustomShape extends ShapeBase {
       this.customSizeWidth = drawLater.nodeDimensions.width;
       this.customSizeHeight = drawLater.nodeDimensions.height;
     }
+
+    this.resize(ctx, selected, hover, values);
+    this.left = x - this.width / 2;
+    this.top = y - this.height / 2;
 
     return drawLater;
   }

--- a/lib/network/modules/components/nodes/shapes/CustomShape.js
+++ b/lib/network/modules/components/nodes/shapes/CustomShape.js
@@ -13,7 +13,7 @@ class CustomShape extends ShapeBase {
    * @param {object} body
    * @param {Label} labelModule
    * @param {Function} ctxRenderer
-   
+
    */
   constructor(options, body, labelModule, ctxRenderer) {
     super(options, body, labelModule, ctxRenderer);

--- a/lib/network/options.ts
+++ b/lib/network/options.ts
@@ -203,6 +203,7 @@ const nodeOptions: OptionsConfig = {
     __type__: { object },
   },
   size: { number },
+  touchPadding: { number },
   title: { string, dom, undefined: "undefined" },
   value: { number, undefined: "undefined" },
   widthConstraint: {

--- a/types/network/Network.d.ts
+++ b/types/network/Network.d.ts
@@ -963,6 +963,8 @@ export interface NodeOptions {
 
   size?: number;
 
+  touchPadding?: number;
+
   title?: string | HTMLElement;
 
   value?: number;


### PR DESCRIPTION
**Thank you for contributing to vis.js!!**

Please make sure to check the following requirements before creating a pull request:

Simple attempt to fix https://github.com/visjs/vis-network/issues/1494

Additionally, custom shapes can now receive the options object in the renderer to further allow customization and external values.

Lastly, added a new option to allow nodes to be tapped / selected beyond their dimensions.  This is to support being able to select small nodes by adding a small padding to them (defaulting to).  Such a small change that another PR didn't make much sense.

