### PR TITLE
Prevent reset the node color to the group color from storePositions function

### DIFF
--- a/lib/network/modules/components/Node.js
+++ b/lib/network/modules/components/Node.js
@@ -323,7 +323,7 @@ class Node {
       (p) => newOptions[p] != null
     );
     // Always skip merging group font options into parent; these are required to be distinct for labels
-    skipProperties.push("font");
+    skipProperties.push(["font", "color"]);
     selectiveNotDeepExtend(skipProperties, parentOptions, groupObj);
 
     // the color object needs to be completely defined.


### PR DESCRIPTION
This pull request fixes the reset of node color when we call to storePositions function.

Example:
before storePositions:
![Screenshot1](https://user-images.githubusercontent.com/42737154/151937535-53633998-98f0-4d85-8abf-cd2dab505231.png)

after storePositions:
![Screenshot2](https://user-images.githubusercontent.com/42737154/151937702-adfd0b2e-b15d-4ca4-8481-8240fa4fb7a3.png)

