### PR TITLE
previous selection returned entire object vs ids

### DIFF
--- a/lib/network/modules/SelectionHandler.js
+++ b/lib/network/modules/SelectionHandler.js
@@ -554,9 +554,20 @@ class SelectionHandler {
     let selected = false;
 
     const selectionChanges = this._selectionAccumulator.commit();
-    const previousSelection = {
-      nodes: selectionChanges.nodes.previous,
-      edges: selectionChanges.edges.previous,
+    const previousSelection = {};
+    var nodes = [];
+    var edges = [];
+    
+    for (let i = 0; i < selectionChanges.nodes.previous.length; i++ ){
+        nodes.push(selectionChanges.nodes.previous[i].id);
+    };
+    for (let i = 0; i < selectionChanges.edges.previous.length; i++ ){
+        edges.push(selectionChanges.edges.previous[i].id);
+    };
+
+    previousSelection = {
+        nodes: nodes,
+        edges: edges
     };
 
     if (selectionChanges.edges.deleted.length > 0) {


### PR DESCRIPTION
Previous selection was returning the entire node and edge objects rather than just an array of ids. This fixes it. I only tested it via modifying the vis-network.min.js file directly, but have translated it back to this format. Please check and improve as necessary. 
`
  value: function (g, A) {
                    var t = !1,
                        e = this._selectionAccumulator.commit(),
                        C = {},
                        nodes = [], 
                        edges = [];
                    
                    for (let i = 0; i < e.nodes.previous.length; i++ ){
                        nodes.push(e.nodes.previous[i].id);
                    };
                    for (let i = 0; i < e.edges.previous.length; i++ ){
                        edges.push(e.edges.previous[i].id);
                    };
                    
                    C = {
                        nodes: nodes,
                        edges: edges
                    };
`

**Thank you for contributing to vis.js!!**

Please make sure to check the following requirements before creating a pull request:

* [ ] All pull requests must be to the [master branch](https://github.com/visjs/vis-network). Pull requests to any other branch will be closed!
* [ ] Make sure your changes are based on the latest version of the [master branch](https://github.com/visjs/vis-network). (Use e.g. `git fetch && git rebase origin master` to update your feature branch).
* [ ] Provide an additional or update an example to demonstrate your changes or new features.
* [ ] Update the documentation if you introduced new behavior or changed existing behavior.
* [ ] Reference issue numbers of issues that your pull request addresses. (If you write something like `fixes #1781` in your git commit message this issue gets closed automatically by merging your pull request).
* [ ] Expect review comments and change requests by reviewer.
* [ ] Delete this checklist from your pull request.
