### PR TITLE
fix(interaction-handler): commit selection change on drag start

### DIFF
--- a/lib/network/modules/InteractionHandler.js
+++ b/lib/network/modules/InteractionHandler.js
@@ -296,8 +296,7 @@ class InteractionHandler {
       this.drag.nodeId = node.id;
       // select the clicked node if not yet selected
       if (node.isSelected() === false) {
-        this.selectionHandler.unselectAll();
-        this.selectionHandler.selectObject(node);
+        this.selectionHandler.setSelection({ nodes: [node.id] });
       }
 
       // after select to contain the node


### PR DESCRIPTION
It was changed but not committed with lead to issues like sometimes the wrong node being moved when dragging.

The `unselectAll` and `selectObject` methods modify the selection but don't commit the selection which is necessary to rerender etc. The `setSelection` method replaces the selection and commits it automatically. This way when an unselected node is dragged it will be selected as the code suggest it should and as it is when the selection is empty.

Closes #1596.
Closes #1599 - This is a workaround that resets the selection to the state before drag to hide #1596, it doesn't solve the issue though, it just hides it.