### PR TITLE
Fix typo in index.html

### DIFF
--- a/docs/network/index.html
+++ b/docs/network/index.html
@@ -250,7 +250,7 @@
                 kept only for backward compatibility, please
                 <strong>don't</strong> use,
               </li>
-              <li>CSS has to be included sepparately,</li>
+              <li>CSS has to be included separately,</li>
               <li>JavaScript dependencies bundled,</li>
               <li>doesn't play well with tree shaking,</li>
               <li>doesn't work with other Vis family packages,</li>


### PR DESCRIPTION
Changed "sepparately" to "separately" in the "getting started" section