### PR TITLE
fix(interaction): initialize selection or dragging/paning but never both

### DIFF
--- a/lib/network/modules/InteractionHandler.js
+++ b/lib/network/modules/InteractionHandler.js
@@ -290,9 +290,7 @@ class InteractionHandler {
         x: this.canvas._XconvertDOMtoCanvas(pointer.x),
         y: this.canvas._YconvertDOMtoCanvas(pointer.y),
       };
-    }
-
-    if (node !== undefined && this.options.dragNodes === true) {
+    } else if (node !== undefined && this.options.dragNodes === true) {
       this.drag.nodeId = node.id;
       // select the clicked node if not yet selected
       if (node.isSelected() === false) {


### PR DESCRIPTION
When shift was pressed and the drag started on a node both were initialized. Afterwards dragging moved the node and drag end finished the selection leaving the node fixed and unable to be dragged again.

Closes #1540.