### PR TITLE
fix(deps): remove timsort

### DIFF
--- a/lib/network/modules/LayoutEngine.js
+++ b/lib/network/modules/LayoutEngine.js
@@ -30,7 +30,6 @@
  * on non-hierarchical networks as well. The converse is also possible.
  */
 "use strict";
-import TimSort from "timsort";
 import {
   Alea,
   deepExtend,
@@ -1506,7 +1505,7 @@ class LayoutEngine {
       result.push(Number(size));
     });
 
-    TimSort.sort(result, function (a, b) {
+    result.sort(function (a, b) {
       return b - a;
     });
 

--- a/lib/network/modules/components/DirectionStrategy.js
+++ b/lib/network/modules/components/DirectionStrategy.js
@@ -4,8 +4,6 @@
  * Strategy pattern for usage of direction methods for hierarchical layouts.
  */
 
-import { sort as timsort } from "timsort";
-
 /**
  * Interface definition for direction strategy classes.
  *
@@ -184,7 +182,7 @@ class VerticalStrategy extends DirectionInterface {
 
   /** @inheritDoc */
   sort(nodeArray) {
-    timsort(nodeArray, function (a, b) {
+    nodeArray.sort(function (a, b) {
       return a.x - b.x;
     });
   }
@@ -249,7 +247,7 @@ class HorizontalStrategy extends DirectionInterface {
 
   /** @inheritDoc */
   sort(nodeArray) {
-    timsort(nodeArray, function (a, b) {
+    nodeArray(function (a, b) {
       return a.y - b.y;
     });
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@types/chai": "4.3.6",
         "@types/mocha": "10.0.2",
         "@types/sinon": "10.0.18",
-        "@types/timsort": "0.3.1",
         "@types/uuid": "9.0.4",
         "compare-versions": "5.0.3",
         "component-emitter": "1.3.0",
@@ -43,7 +42,6 @@
         "sinon": "16.1.0",
         "snap-shot-it": "7.9.10",
         "start-server-and-test": "2.0.1",
-        "timsort": "0.3.0",
         "tmp-promise": "3.0.2",
         "uuid": "9.0.1",
         "vis-data": "7.1.7",
@@ -58,7 +56,6 @@
         "@egjs/hammerjs": "^2.0.0",
         "component-emitter": "^1.3.0",
         "keycharm": "^0.2.0 || ^0.3.0 || ^0.4.0",
-        "timsort": "^0.3.0",
         "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
         "vis-data": "^6.3.0 || ^7.0.0",
         "vis-util": "^5.0.1"
@@ -3843,12 +3840,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
       "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
-      "dev": true
-    },
-    "node_modules/@types/timsort": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@types/timsort/-/timsort-0.3.1.tgz",
-      "integrity": "sha512-38S7oiq19/5kTjXe6UEDjtHXQILji7n83HmbrfOkFc5mr7O/k8ldW4PABd3e/GaK5nFdcOLjvwD1MxtJO+VybA==",
       "dev": true
     },
     "node_modules/@types/uuid": {
@@ -20037,12 +20028,6 @@
       "integrity": "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw==",
       "dev": true,
       "peer": true
-    },
-    "node_modules/timsort": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-      "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
-      "dev": true
     },
     "node_modules/tinycolor2": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "@egjs/hammerjs": "^2.0.0",
     "component-emitter": "^1.3.0",
     "keycharm": "^0.2.0 || ^0.3.0 || ^0.4.0",
-    "timsort": "^0.3.0",
     "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
     "vis-data": "^6.3.0 || ^7.0.0",
     "vis-util": "^5.0.1"
@@ -113,7 +112,6 @@
     "@types/chai": "4.3.6",
     "@types/mocha": "10.0.2",
     "@types/sinon": "10.0.18",
-    "@types/timsort": "0.3.1",
     "@types/uuid": "9.0.4",
     "compare-versions": "5.0.3",
     "component-emitter": "1.3.0",
@@ -137,7 +135,6 @@
     "sinon": "16.1.0",
     "snap-shot-it": "7.9.10",
     "start-server-and-test": "2.0.1",
-    "timsort": "0.3.0",
     "tmp-promise": "3.0.2",
     "uuid": "9.0.1",
     "vis-data": "7.1.7",

--- a/rollup.build.js
+++ b/rollup.build.js
@@ -10,7 +10,6 @@ export default generateRollupConfiguration({
     "vis-data": "vis",
     "vis-util": "vis",
     keycharm: "keycharm",
-    timsort: "timsort",
     uuid: "uuid",
   },
   header: { name: "vis-network" },


### PR DESCRIPTION
Up to the ECMAScript standard `Array.sort` is stable and all the browsers that we polyfill already implement it that way so we don't need timsort anymore.