### PR TITLE
chore(package): remove opencollective

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "vis-network",
       "version": "0.0.0-no-version",
-      "hasInstallScript": true,
       "license": "(Apache-2.0 OR MIT)",
       "devDependencies": {
         "@babel/plugin-proposal-object-rest-spread": "7.18.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "lint": "eslint --ext .js,.ts .",
     "lint-fix": "eslint --fix --ext .js,.ts .",
     "clean": "shx rm -rf \"declarations\" \"dist\" \"examples/index.html\" \"examples/static/*\" \"peer\" \"standalone\" \"styles\" \"vis-network*\" \"cypress/{fixtures,integration,pages,support}/**/*.js{,.map}\" \"cypress/snapshots/{actual,diff}/*\"",
-    "postinstall": "opencollective postinstall || exit 0",
     "prepare": "husky install"
   },
   "husky": {
@@ -93,9 +92,6 @@
       "sortSnapshots": true,
       "useRelativePath": true
     }
-  },
-  "dependency": {
-    "opencollective": "1.0.3"
   },
   "peerDependencies": {
     "@egjs/hammerjs": "^2.0.0",
@@ -147,9 +143,5 @@
     "vis-data": "7.1.6",
     "vis-dev-utils": "4.0.6",
     "vis-util": "5.0.3"
-  },
-  "collective": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/visjs"
   }
 }


### PR DESCRIPTION
We used this to notify people about the funding of our project but this is now handled by npm natively via fund in the package, which we already have, and via npm fund. Furthermore the dependency is no longer maintained (last update is 6 years ago).

Also, at least on my machine, it only seems to output:
```text
> opencollective postinstall || exit 0

sh: line 1: opencollective: command not found
```
anyway.