### PR TITLE
Make central gravity force proportional to node mass.

### DIFF
--- a/lib/network/modules/components/physics/CentralGravitySolver.js
+++ b/lib/network/modules/components/physics/CentralGravitySolver.js
@@ -53,7 +53,9 @@ class CentralGravitySolver {
    */
   _calculateForces(distance, dx, dy, forces, node) {
     const gravityForce =
-      distance === 0 ? 0 : this.options.centralGravity / distance;
+      distance === 0
+        ? 0
+        : (this.options.centralGravity * node.options.mass) / distance;
     forces[node.id].x = dx * gravityForce;
     forces[node.id].y = dy * gravityForce;
   }


### PR DESCRIPTION
fixes #1963

The central force should be proportional to the mass of the node.