### PR TITLE
Fix typo in layout.html documentation

### DIFF
--- a/docs/network/layout.html
+++ b/docs/network/layout.html
@@ -374,7 +374,7 @@ network.setOptions(options);
           <tr parent="hierarchical" class="hidden">
             <td class="indent">hierarchical.shakeTowards</td>
             <td>String</td>
-            <td><code>'roots'</code></td>
+            <td><code>'leaves'</code></td>
             <td>
               Controls whether in <code>directed</code> layout should all the
               roots be lined up at the top and their child nodes as close to


### PR DESCRIPTION
The documentation seemed to have a simple mistake, where `leaves` is the default parameter rather than `roots`.
