### PR TITLE
fix(horizontal-strategy): add missing sort method

### DIFF
--- a/lib/network/modules/components/DirectionStrategy.js
+++ b/lib/network/modules/components/DirectionStrategy.js
@@ -247,7 +247,7 @@ class HorizontalStrategy extends DirectionInterface {
 
   /** @inheritDoc */
   sort(nodeArray) {
-    nodeArray(function (a, b) {
+    nodeArray.sort(function (a, b) {
       return a.y - b.y;
     });
   }


### PR DESCRIPTION
`.sort()` was missing in HorizontalStrategy in #1946