### PR TITLE
perf: remove add/remove event listener polyfills

### DIFF
--- a/lib/network/modules/Canvas.js
+++ b/lib/network/modules/Canvas.js
@@ -1,11 +1,6 @@
 import { onRelease, onTouch } from "../../hammerUtil";
 
-import {
-  Hammer,
-  addEventListener,
-  removeEventListener,
-  selectiveDeepExtend,
-} from "vis-util/esnext";
+import { Hammer, selectiveDeepExtend } from "vis-util/esnext";
 
 /**
  * Create the main frame for the Network.
@@ -98,9 +93,9 @@ class Canvas {
 
       // Automatically adapt to changing size of the browser.
       const resizeFunction = this._onResize.bind(this);
-      addEventListener(window, "resize", resizeFunction);
+      window.addEventListener("resize", resizeFunction);
       this._cleanupCallbacks.push(() => {
-        removeEventListener(window, "resize", resizeFunction);
+        window.removeEventListener("resize", resizeFunction);
       });
     }
   }


### PR DESCRIPTION
These are polyfills for very old browsers. We don't polyfill these browsers using core-js (i.e. it most likely doesn't work in them anyway) and barely anyone is using them nowadays.