### PR TITLE
chore(cypress): remove some custom transpilation

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -13,12 +13,12 @@ export default defineConfig({
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.
     async setupNodeEvents(on, config) {
-      return (await import("./cypress/plugins/index.js")).default(on, config);
+      return (await import("./cypress/plugins/index.ts")).default(on, config);
     },
     specPattern: [
-      "cypress/e2e/visual/**/*.spec.js",
-      "cypress/e2e/functional/**/*.spec.js",
+      "cypress/e2e/visual/**/*.spec.ts",
+      "cypress/e2e/functional/**/*.spec.ts",
     ],
-    supportFile: "cypress/support/e2e.js",
+    supportFile: "cypress/support/e2e.ts",
   },
 });

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -7,12 +7,12 @@
 // You can read more here:
 // https://on.cypress.io/plugins-guide
 // ***********************************************************
-const getCompareSnapshotsPlugin = require("cypress-visual-regression/dist/plugin");
+import getCompareSnapshotsPlugin from "cypress-visual-regression/dist/plugin";
 
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
-module.exports = (on, config) => {
+export default (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
 
@@ -22,7 +22,7 @@ module.exports = (on, config) => {
 
   if (all || config.env.VISUAL) {
     // Visual regression screenshot tests.
-    config.specPattern.push("cypress/e2e/visual/**/*.spec.js");
+    config.specPattern.push("cypress/e2e/visual/**/*.spec.ts");
     config.env.failSilently = false;
     config.trashAssetsBeforeRuns = true;
 
@@ -39,7 +39,7 @@ module.exports = (on, config) => {
 
   if (all || config.env.FUNCTIONAL) {
     // Functional tests.
-    config.specPattern.push("cypress/e2e/functional/**/*.spec.js");
+    config.specPattern.push("cypress/e2e/functional/**/*.spec.ts");
   }
 
   return config;

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -3,11 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["esnext", "dom"],
-    "module": "es2020",
-    "outDir": ".",
-    "target": "es2015",
-    "types": ["cypress"]
+    "outDir": "."
   },
-  "exclude": ["../node_modules", "./plugins", "./screenshots", "./videos"],
-  "include": ["**/*.ts"]
+  "exclude": ["../node_modules"],
+  "include": ["pages/**/*.ts"]
 }


### PR DESCRIPTION
It's not necessary anymore, Cypress works just fine with TS files now. The transpilation is kept for files that are loaded from served HTML files though as that has to be transpiled manually.