### PR TITLE
Fix issues #1600 - Arrow heads rendered above labels

### DIFF
--- a/lib/network/modules/CanvasRenderer.js
+++ b/lib/network/modules/CanvasRenderer.js
@@ -308,6 +308,8 @@ class CanvasRenderer {
             (this.zooming === true && this.options.hideEdgesOnZoom === false))
         ) {
           this._drawEdges(ctx);
+          // draw arrows first so they end up below nodes
+          this._drawArrows(ctx);
         }
       }
 
@@ -317,19 +319,6 @@ class CanvasRenderer {
       ) {
         const { drawExternalLabels } = this._drawNodes(ctx, hidden);
         drawLater.drawExternalLabels = drawExternalLabels;
-      }
-
-      // draw the arrows last so they will be at the top
-      if (hidden === false) {
-        if (
-          (this.dragging === false ||
-            (this.dragging === true &&
-              this.options.hideEdgesOnDrag === false)) &&
-          (this.zooming === false ||
-            (this.zooming === true && this.options.hideEdgesOnZoom === false))
-        ) {
-          this._drawArrows(ctx);
-        }
       }
 
       if (drawLater.drawExternalLabels != null) {


### PR DESCRIPTION
This update addresses the issue by adjusting the rendering order during the edge creation process. Specifically, arrowheads are now rendered after the edges are drawn but before the node labels are applied. This ensures that node labels remain visible and unobstructed by the arrowheads.

Changes Implemented on:
Updated CanvasRender.js