### PR TITLE
perf(canvas-renderer): remove requestAnimationFrame polyfill/compat

### DIFF
--- a/lib/network/modules/CanvasRenderer.js
+++ b/lib/network/modules/CanvasRenderer.js
@@ -1,48 +1,6 @@
 import { selectiveDeepExtend } from "vis-util/esnext";
 
 /**
- * Initializes window.requestAnimationFrame() to a usable form.
- *
- * Specifically, set up this method for the case of running on node.js with jsdom enabled.
- *
- * NOTES:
- *
- * On node.js, when calling this directly outside of this class, `window` is not defined.
- * This happens even if jsdom is used.
- * For node.js + jsdom, `window` is available at the moment the constructor is called.
- * For this reason, the called is placed within the constructor.
- * Even then, `window.requestAnimationFrame()` is not defined, so it still needs to be added.
- * During unit testing, it happens that the window object is reset during execution, causing
- * a runtime error due to missing `requestAnimationFrame()`. This needs to be compensated for,
- * see `_requestNextFrame()`.
- * Since this is a global object, it may affect other modules besides `Network`. With normal
- * usage, this does not cause any problems. During unit testing, errors may occur. These have
- * been compensated for, see comment block in _requestNextFrame().
- * @private
- */
-function _initRequestAnimationFrame() {
-  let func;
-
-  if (window !== undefined) {
-    func =
-      window.requestAnimationFrame ||
-      window.mozRequestAnimationFrame ||
-      window.webkitRequestAnimationFrame ||
-      window.msRequestAnimationFrame;
-  }
-
-  if (func === undefined) {
-    // window or method not present, setting mock requestAnimationFrame
-    window.requestAnimationFrame = function (callback) {
-      //console.log("Called mock requestAnimationFrame");
-      callback();
-    };
-  } else {
-    window.requestAnimationFrame = func;
-  }
-}
-
-/**
  * The canvas renderer
  */
 class CanvasRenderer {
@@ -51,13 +9,11 @@ class CanvasRenderer {
    * @param {Canvas} canvas
    */
   constructor(body, canvas) {
-    _initRequestAnimationFrame();
     this.body = body;
     this.canvas = canvas;
 
     this.redrawRequested = false;
-    this.renderTimer = undefined;
-    this.requiresTimeout = true;
+    this.requestAnimationFrameRequestId = undefined;
     this.renderingActive = false;
     this.renderRequests = 0;
     this.allowRedraw = true;
@@ -72,7 +28,6 @@ class CanvasRenderer {
     };
     Object.assign(this.options, this.defaultOptions);
 
-    this._determineBrowserMethod();
     this.bindEventListeners();
   }
 
@@ -118,17 +73,13 @@ class CanvasRenderer {
     this.body.emitter.on("_stopRendering", () => {
       this.renderRequests -= 1;
       this.renderingActive = this.renderRequests > 0;
-      this.renderTimer = undefined;
+      this.requestAnimationFrameRequestId = undefined;
     });
     this.body.emitter.on("destroy", () => {
       this.renderRequests = 0;
       this.allowRedraw = false;
       this.renderingActive = false;
-      if (this.requiresTimeout === true) {
-        clearTimeout(this.renderTimer);
-      } else {
-        window.cancelAnimationFrame(this.renderTimer);
-      }
+      window.cancelAnimationFrame(this.requestAnimationFrameRequestId);
       this.body.emitter.off();
     });
   }
@@ -145,53 +96,13 @@ class CanvasRenderer {
   }
 
   /**
-   * Prepare the drawing of the next frame.
-   *
-   * Calls the callback when the next frame can or will be drawn.
-   * @param {Function} callback
-   * @param {number} delay - timeout case only, wait this number of milliseconds
-   * @returns {Function | undefined}
-   * @private
-   */
-  _requestNextFrame(callback, delay) {
-    // During unit testing, it happens that the mock window object is reset while
-    // the next frame is still pending. Then, either 'window' is not present, or
-    // 'requestAnimationFrame()' is not present because it is not defined on the
-    // mock window object.
-    //
-    // As a consequence, unrelated unit tests may appear to fail, even if the problem
-    // described happens in the current unit test.
-    //
-    // This is not something that will happen in normal operation, but we still need
-    // to take it into account.
-    //
-    if (typeof window === "undefined") return; // Doing `if (window === undefined)` does not work here!
-
-    let timer;
-
-    const myWindow = window; // Grab a reference to reduce the possibility that 'window' is reset
-    // while running this method.
-
-    if (this.requiresTimeout === true) {
-      // wait given number of milliseconds and perform the animation step function
-      timer = myWindow.setTimeout(callback, delay);
-    } else {
-      if (myWindow.requestAnimationFrame) {
-        timer = myWindow.requestAnimationFrame(callback);
-      }
-    }
-
-    return timer;
-  }
-
-  /**
    *
    * @private
    */
   _startRendering() {
     if (this.renderingActive === true) {
-      if (this.renderTimer === undefined) {
-        this.renderTimer = this._requestNextFrame(
+      if (this.requestAnimationFrameRequestId === undefined) {
+        this.requestAnimationFrameRequestId = window.requestAnimationFrame(
           this._renderStep.bind(this),
           this.simulationInterval
         );
@@ -205,20 +116,13 @@ class CanvasRenderer {
    */
   _renderStep() {
     if (this.renderingActive === true) {
-      // reset the renderTimer so a new scheduled animation step can be set
-      this.renderTimer = undefined;
+      // reset the requestAnimationFrameRequestId so a new scheduled animation step can be set
+      this.requestAnimationFrameRequestId = undefined;
 
-      if (this.requiresTimeout === true) {
-        // this schedules a new simulation step
-        this._startRendering();
-      }
+      // this schedules a new simulation step
+      this._startRendering();
 
       this._redraw();
-
-      if (this.requiresTimeout === false) {
-        // this schedules a new simulation step
-        this._startRendering();
-      }
     }
   }
 
@@ -242,9 +146,9 @@ class CanvasRenderer {
       this.allowRedraw === true
     ) {
       this.redrawRequested = true;
-      this._requestNextFrame(() => {
+      window.requestAnimationFrame(() => {
         this._redraw(false);
-      }, 0);
+      });
     }
   }
 
@@ -492,29 +396,6 @@ class CanvasRenderer {
       if (edge.connected === true) {
         edge.drawArrows(ctx);
       }
-    }
-  }
-
-  /**
-   * Determine if the browser requires a setTimeout or a requestAnimationFrame. This was required because
-   * some implementations (safari and IE9) did not support requestAnimationFrame
-   * @private
-   */
-  _determineBrowserMethod() {
-    if (typeof window !== "undefined") {
-      const browserType = navigator.userAgent.toLowerCase();
-      this.requiresTimeout = false;
-      if (browserType.indexOf("msie 9.0") != -1) {
-        // IE 9
-        this.requiresTimeout = true;
-      } else if (browserType.indexOf("safari") != -1) {
-        // safari
-        if (browserType.indexOf("chrome") <= -1) {
-          this.requiresTimeout = true;
-        }
-      }
-    } else {
-      this.requiresTimeout = true;
     }
   }
 

--- a/test/canvas-mock.js
+++ b/test/canvas-mock.js
@@ -155,6 +155,12 @@ export function canvasMockify(html = "") {
     virtualConsole: virtualConsole,
   });
 
+  // TODO: JSDOM doesn't polyfill this. Find a better solution, maybe switch to
+  // Happy DOM or Vitest browser mode?
+  window.requestAnimationFrame = (callback) =>
+    setTimeout(() => callback(Date.now()), 0);
+  window.cancelAnimationFrame = (id) => clearTimeout(id);
+
   overrideCreateElement(window); // The actual initialization of canvas-mock
 
   overrideCreateElementNS(window);


### PR DESCRIPTION
This served unsupported browsers (IE 9 era, no longer supported) and our test setup without proper polyfills for necessary browser APIs.

I mostly need to remove this because without it I can't merge all of the updates that are still pending across Vis.js repos. With updated dependencies it fails on maximum call stack size exceeded. Though it also cuts down on bundle size and reduces overhead.