### PR TITLE
refactor(styles): remove CSS from tests

### DIFF
--- a/lib/entry-esnext.ts
+++ b/lib/entry-esnext.ts
@@ -1,3 +1,11 @@
+import "./network/modules/ManipulationSystem.css";
+import "./network/modules/components/NavigationHandler.css";
+import "vis-util/esnext/styles/activator.css";
+import "vis-util/esnext/styles/bootstrap.css";
+import "vis-util/esnext/styles/color-picker.css";
+import "vis-util/esnext/styles/configurator.css";
+import "vis-util/esnext/styles/popup.css";
+
 export * from "./network/Network";
 
 export { default as NetworkImages } from "./network/Images";

--- a/lib/index-legacy.ts
+++ b/lib/index-legacy.ts
@@ -1,4 +1,12 @@
 // Network.
+import "./network/modules/ManipulationSystem.css";
+import "./network/modules/components/NavigationHandler.css";
+import "vis-util/esnext/styles/activator.css";
+import "vis-util/esnext/styles/bootstrap.css";
+import "vis-util/esnext/styles/color-picker.css";
+import "vis-util/esnext/styles/configurator.css";
+import "vis-util/esnext/styles/popup.css";
+
 export * from "./network/Network";
 
 import Images from "./network/Images";

--- a/lib/network/Network.js
+++ b/lib/network/Network.js
@@ -1,12 +1,6 @@
 // Load custom shapes into CanvasRenderingContext2D
 import "./shapes";
 
-import "vis-util/esnext/styles/activator.css";
-import "vis-util/esnext/styles/bootstrap.css";
-import "vis-util/esnext/styles/color-picker.css";
-import "vis-util/esnext/styles/configurator.css";
-import "vis-util/esnext/styles/popup.css";
-
 import Emitter from "component-emitter";
 import {
   Activator,

--- a/lib/network/modules/ManipulationSystem.js
+++ b/lib/network/modules/ManipulationSystem.js
@@ -1,5 +1,3 @@
-import "./ManipulationSystem.css";
-
 import { Hammer, deepExtend, recursiveDOMDelete } from "vis-util/esnext";
 import { v4 as randomUUID } from "uuid";
 import { onTouch } from "../../hammerUtil";

--- a/lib/network/modules/components/NavigationHandler.js
+++ b/lib/network/modules/components/NavigationHandler.js
@@ -1,5 +1,3 @@
-import "./NavigationHandler.css";
-
 import { Hammer } from "vis-util/esnext";
 import { onRelease, onTouch } from "../../../hammerUtil";
 import keycharm from "keycharm";


### PR DESCRIPTION
Tests run in Node without CSS support. The style imports were ignored anyway. Not importing CSS into tests in the first place will make things easier, especially transition to ESM where require won't work.