### PR TITLE
Adding a zindex feature

### DIFF
--- a/lib/network/Network.js
+++ b/lib/network/Network.js
@@ -124,6 +124,12 @@ export function Network(container, data, options) {
     },
   };
 
+  //zindex body properties if needed. Must be set before bindEventListeners() and NodesHandler construction: zindex events will only be bound if necessary 
+  if(options.zIndexField){
+    this.body.zIndexField = options.zIndexField; // needed in Node.setOption(), has to know which field is the zIndex field, if any.
+    this.body.zIndexCompare = options.zIndexCompare || ((a,b)=>(parseInt(a)||0)-(parseInt(b)||0)); // defaults to integer comparison if nothing else given, any invalid int worth zero
+  } 
+
   // bind the event listeners
   this.bindEventListeners();
 
@@ -361,6 +367,10 @@ Network.prototype.bindEventListeners = function () {
     // Order important in following block
     this.clustering._updateState();
     this._updateVisibleIndices();
+
+    if(this.body.zIndexField && this.body.zIndexCompare){//currently tested both before calling and in function, maybe not useful
+      this.nodesHandler.zindexSortNodeIndices();
+    }
 
     this._updateValueRange(this.body.nodes);
     this._updateValueRange(this.body.edges);

--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -166,6 +166,10 @@ class NodesHandler {
     // refresh the nodes. Used when reverting from hierarchical layout
     this.body.emitter.on("refreshNodes", this.refresh.bind(this));
     this.body.emitter.on("refresh", this.refresh.bind(this));
+    if(this.body.zIndexField && this.body.zIndexCompare){// after refreshing, also zindex-sort if a zindex is configured
+        this.body.emitter.on("refresh", this.zindexSortNodeIndices.bind(this));
+        this.body.emitter.on("refreshNodes", this.zindexSortNodeIndices.bind(this));
+    }
     this.body.emitter.on("destroy", () => {
       forEach(this.nodesListeners, (callback, event) => {
         if (this.body.data.nodes) this.body.data.nodes.off(event, callback);
@@ -404,6 +408,15 @@ class NodesHandler {
         node.setOptions(data);
       }
     });
+  }
+  
+  zindexSortNodeIndices(){
+    const zindex = this.body.zIndexField;
+    const comp =  this.body.zIndexCompare;
+    if(zindex && comp){//test not really necessary if previously tested before adding an Emitter event handler
+      const nodes = this.body.nodes;
+      this.body.nodeIndices.sort((a,b)=>comp(nodes[a].options[zindex], nodes[b].options[zindex]));
+    }
   }
 
   /**

--- a/lib/network/modules/components/Node.js
+++ b/lib/network/modules/components/Node.js
@@ -114,18 +114,22 @@ class Node {
    * @returns {null|boolean}
    */
   setOptions(options) {
-    const currentShape = this.options.shape;
-
     if (!options) {
       return; // Note that the return value will be 'undefined'! This is OK.
     }
 
+    const currentShape = this.options.shape;
+    const zIdField = this.body.zIndexField;
     // Save the color for later.
     // This is necessary in order to prevent local color from being overwritten by group color.
     // TODO: To prevent such workarounds the way options are handled should be rewritten from scratch.
     // This is not the only problem with current options handling.
     if (typeof options.color !== "undefined") {
       this._localColor = options.color;
+    }
+    //same logic and same comment as above. Thanks for the workaround.
+    if (zIdField && typeof options[zIdField] !== "undefined") {
+      this._zindex = options[zIdField];
     }
 
     // basic options
@@ -185,6 +189,9 @@ class Node {
     if (options.opacity !== undefined && Node.checkOpacity(options.opacity)) {
       this.options.opacity = options.opacity;
     }
+    // Need to set local zindex after `Node.parseOptions(...);` and `this.updateLabelModule(options)` otherwise it's overwritten with group's zindex
+    this.options[zIdField] = this._zindex ?? this.grouplist.get(this.options.group)[zIdField] ?? this.globalOptions[zIdField] ?? undefined; // we want new option's zindex if given, otherwise previous own zindex, NOT group's zindex
+    //notice: using ?? and not || because 0 IS a valid zindex, only null or undefined are not
 
     this.updateShape(currentShape);
 
@@ -492,12 +499,13 @@ class Node {
     if (this.options.label === undefined || this.options.label === null) {
       this.options.label = "";
     }
-
+    const zIdField = this.body.zIndexField;
     Node.updateGroupOptions(
       this.options,
       {
         ...options,
         color: (options && options.color) || this._localColor || undefined,
+        zindex: (options && options[zIdField]) || this._zindex || undefined
       },
       this.grouplist,
     );

--- a/lib/network/options.ts
+++ b/lib/network/options.ts
@@ -545,6 +545,8 @@ const allOptions: OptionsConfig = {
   },
   height: { string },
   width: { string },
+  zIndexField: { string },
+  zIndexCompare : { function: "function" },
   __type__: { object },
 };
 /* eslint-enable @typescript-eslint/naming-convention */


### PR DESCRIPTION
### Adding a zindex feature.

**Purpose: allow the user to decide which nodes should come above others.**

To achieve this, I added two options:

 - `zIndexField`: a string containing a node option name.
		This aims at allowing the user to choose which node field shall be used to decide what comes to front and what stays behind.
		It might be a dedicated zindex node option, it might as well be any node property, such as label (A on top of B, C, D...), age, zipcode, date, time, density, whatever comes useful depending on the real things represented by the nodes.
		If not given, then simply nothing happens.
		
 - `zIndexCompare`: a callback receiving two node zindexes Z1 a and Z2, and returning positive, 0 or negative to tell if Z1 shall be on top of, indifferent or behind Z2.
		This aims at letting the user choose his own ranking (ascending, descending), but also to give a comparing callback adapted to the type of his zindexes (int, float, string, date, whatever).
			If not given, the default callback is an integer comparison, greatest zindex to the front: `(a,b)=>(parseInt(a)||0)-(parseInt(b)||0)`
			Important notice: the custom compare callback must work properly on null or undefined zindexes
			(see the `||0` clauses in the default callback mentionned above).

Theoretically, these options are just needed in the Network and NodesHandler module:
the visible nodes are rendered such as their indexes are listed in body.nodeIndices.
So I added a zindexSortNodeIndices() method in class NodesHandler, which just does an array.sort() using the callback stored in zIndexCompare.

This method is bound to folowing events:
	- "refresh" and "refreshNodes" in NodesHandler,
	- "_dataUpdated" in Network.
These two calls seem sufficient, from my tests, to cover all cases I could imagine: changing a node's zindex, changing a group's zindex, changing a node from a group to another.
Please tell me if you think it should be triggered by other events.


Ok, now this looked well and good, and I thought it should have done the job...
... but still I spent hours to figure out why the node's zindex sometimes got lost when updating groups or changing to another group.
Then I figured out -or at least this is how I understood it:

Node.setOption() (and parseOptions, and...) doesn't keep track of the node's OWN options; these get replaced with group options. At least if a node does not have an option, it gets the group's option, but the information "hey man, I've got no OWN option here" is lost. So when changing group, or updating group, there's no knowing if the new group option should replace the node's option because it's an option of the previous group, or should be ignored because it's a node's OWN option which must prevail. I saw from other's workarounds and comments for other options that I wasn't the first one to struggle around here.

So I had to go with my own workaround too. This is the reason for the mods in Node.setOptions() and Node.updateLabelModule().
An access to zIndexField option is therefore needed in Nodes too, caus' I needed to identify there, about what field I was writing a workaround. It would have looked stupid to duplicate this option onto all and every node in the Network, so the only other way I found was to expose the zIndexField as a property of body.
So as not to have different ways of dealing with two options that are intimely bound, I also exposed zIndexCompare there, although it's just used in NodesHandler and probably could just be an inherited option from Network.
Here again, if there's a better solution than exposing options onto body, tell me; I think it's a more general problem in options handling, there probably should be a distinction at some point between own options and inherited options. But this wasn't my point and, just discovering the internals of visjs Network, I'm not pretending I understand enough of the project globally to have a pertinent opinion on this subject ;-)

I'll propose the corresponding documentation updates as soon as this PR is validated.

**Last disclaimer:**
I'm no usual git user, and not equiped to modify and build my own fork, so I made all edits on a pre-built downloaded vis-network.js script file:
		-> npm install vis-network
		-> then I used and modified the vis-network.js from folder standalone/umd/
				(I'd be happy to be directed to an easy how-to-fork-and-npm-install-your-fork, using github just online on github.com)
All modifications I made were tested in my usecase project, I then reported these modifications into the corresponding parts of visjs project on github.com.
It's the best I could do in the time I could afford to contribute on this project.
In enclosed zip: a little test-case (see folder libjs: the original vis-network.js I worked on, and my modified version).
[mindmap-zindex-test.zip](https://github.com/user-attachments/files/25268237/mindmap-zindex-test.zip)
