### PR TITLE
Allow wind to be a function of nodeId

### DIFF
--- a/docs/network/physics.html
+++ b/docs/network/physics.html
@@ -667,12 +667,20 @@ network.setOptions(options);
           onclick="toggleTable('optionTable','wind', this);"
         >
           <td><span parent="wind" class="right-caret"></span> wind</td>
-          <td>Object</td>
+          <td>Object | Function</td>
           <td><code>Object</code></td>
           <td>
             A force that pushes all non-fixed nodes in the given direction.<br />Requires
             all nodes are connected to nodes which are `fixed`, otherwise
-            non-attached nodes will keep moving indefinitely.
+            non-attached nodes will keep moving indefinitely. When supplying a
+            function, you receive one argument, the node id. The function should
+            return an object with x and y values. Example:
+            <pre class="prettyprint lang-js">
+function (nodeId) {
+  return { x: 0, y: 10 };
+}
+</pre
+            >
           </td>
         </tr>
         <tr parent="wind" class="hidden">

--- a/examples/network/physics/wind.html
+++ b/examples/network/physics/wind.html
@@ -18,17 +18,20 @@
   </head>
   <body>
     <p>
-      Node 1 is fixed, while a "wind" force pushes other nodes to the right.
+      Node 1 is fixed, while a "wind" force pushes blue nodes to the right, and
+      green nodes down.
     </p>
 
     <div id="mynetwork"></div>
 
     <script type="text/javascript">
+      const GREEN = "#9FE2BF";
+
       // create an array with nodes
       var nodes = new vis.DataSet([
         { id: 1, label: "Node 1", fixed: true },
-        { id: 2, label: "Node 2" },
-        { id: 3, label: "Node 3" },
+        { id: 2, label: "Node 2", color: GREEN },
+        { id: 3, label: "Node 3", color: GREEN },
         { id: 4, label: "Node 4" },
         { id: 5, label: "Node 5" },
       ]);
@@ -48,7 +51,21 @@
         nodes: nodes,
         edges: edges,
       };
-      var options = { physics: { enabled: true, wind: { x: 1, y: 0 } } };
+
+      function wind(nodeId) {
+        if (typeof nodeId === "string" && nodeId.startsWith("edgeId:")) {
+          // Bezier control point.  You can inspect the corresponding edge with
+          // let edge = edges.get(nodeId.substring("edgeId:".length));
+
+          return { x: -0.3, y: -0.3 };
+        }
+
+        var node = nodes.get(nodeId);
+
+        return node && node.color === GREEN ? { x: 0, y: 1.1 } : { x: 1, y: 0 };
+      }
+
+      var options = { physics: { enabled: true, wind } };
       var network = new vis.Network(container, data, options);
     </script>
   </body>

--- a/examples/network/physics/windFunction.html
+++ b/examples/network/physics/windFunction.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <title>Vis Network | Physics | Wind</title>
+    <title>Vis Network | Physics | Wind Function</title>
 
     <script
       type="text/javascript"
@@ -18,17 +18,20 @@
   </head>
   <body>
     <p>
-      Node 1 is fixed, while a "wind" force pushes other nodes to the right.
+      Node 1 is fixed, while a "wind" force pushes blue nodes to the right, and
+      green nodes down.
     </p>
 
     <div id="mynetwork"></div>
 
     <script type="text/javascript">
+      const GREEN = "#9FE2BF";
+
       // create an array with nodes
       var nodes = new vis.DataSet([
         { id: 1, label: "Node 1", fixed: true },
-        { id: 2, label: "Node 2" },
-        { id: 3, label: "Node 3" },
+        { id: 2, label: "Node 2", color: GREEN },
+        { id: 3, label: "Node 3", color: GREEN },
         { id: 4, label: "Node 4" },
         { id: 5, label: "Node 5" },
       ]);
@@ -48,7 +51,21 @@
         nodes: nodes,
         edges: edges,
       };
-      var options = { physics: { enabled: true, wind: { x: 1, y: 0 } } };
+
+      function wind(nodeId) {
+        if (typeof nodeId === "string" && nodeId.startsWith("edgeId:")) {
+          // Bezier control point.  You can inspect the corresponding edge with
+          // let edge = edges.get(nodeId.substring("edgeId:".length));
+
+          return { x: -0.3, y: -0.3 };
+        }
+
+        var node = nodes.get(nodeId);
+
+        return node && node.color === GREEN ? { x: 0, y: 1.1 } : { x: 1, y: 0 };
+      }
+
+      var options = { physics: { enabled: true, wind } };
       var network = new vis.Network(container, data, options);
     </script>
   </body>

--- a/lib/network/modules/PhysicsEngine.js
+++ b/lib/network/modules/PhysicsEngine.js
@@ -180,7 +180,7 @@ class PhysicsEngine {
         }
 
         const wind = this.options.wind;
-        if (wind) {
+        if (wind && typeof wind !== "function") {
           if (typeof wind.x !== "number" || Number.isNaN(wind.x)) {
             wind.x = 0;
           }
@@ -611,8 +611,20 @@ class PhysicsEngine {
     const force = this.physicsBody.forces[nodeId];
 
     if (this.options.wind) {
-      force.x += this.options.wind.x;
-      force.y += this.options.wind.y;
+      if (typeof this.options.wind === "function") {
+        const wind = this.options.wind(nodeId);
+        if (wind && typeof wind === "object") {
+          if (typeof wind.x === "number" && !Number.isNaN(wind.x)) {
+            force.x += wind.x;
+          }
+          if (typeof wind.y === "number" && !Number.isNaN(wind.y)) {
+            force.y += wind.y;
+          }
+        }
+      } else {
+        force.x += this.options.wind.x;
+        force.y += this.options.wind.y;
+      }
     }
 
     const velocity = this.physicsBody.velocities[nodeId];

--- a/lib/network/options.ts
+++ b/lib/network/options.ts
@@ -530,7 +530,7 @@ const allOptions: OptionsConfig = {
     wind: {
       x: { number },
       y: { number },
-      __type__: { object },
+      __type__: { object, function: "function" },
     },
     __type__: { object, boolean: bool },
   },
@@ -836,6 +836,15 @@ export const configuratorHideOption: ConfiguratorHideOption = (
     (configureOptions as any).physics.solver.includes(optionName) &&
     options.physics.solver !== optionName &&
     optionName !== "wind"
+  ) {
+    return true;
+  }
+
+  if (
+    parentPath.includes("physics") &&
+    parentPath.includes("wind") &&
+    (optionName === "x" || optionName === "y") &&
+    typeof options?.physics?.wind === "function"
   ) {
     return true;
   }

--- a/test/physics/wind.test.ts
+++ b/test/physics/wind.test.ts
@@ -44,4 +44,38 @@ describe("wind", function (): void {
     expect(positions[3].x).to.be.greaterThan(0);
     expect(positions[4].x).to.be.greaterThan(0);
   });
+
+  it("Per node wind pushes correctly", async function (): Promise<void> {
+    // node 2 gets pushed to the right, node 3 gets pushed down
+    function wind(nodeId: number): { x: number; y: number } {
+      if (nodeId == 2) {
+        return { x: 10, y: 0 };
+      }
+      if (nodeId == 3) {
+        return { x: 0, y: 10 };
+      }
+      return { x: 0, y: 0 };
+    }
+
+    const network = new Network(
+      this.container,
+      {
+        nodes: [{ id: 1, fixed: true, x: 0, y: 0 }, { id: 2 }, { id: 3 }],
+        edges: [
+          { from: 1, to: 2 },
+          { from: 1, to: 3 },
+        ],
+      },
+      { physics: { wind, stabilization: { iterations: 10 } } },
+    );
+
+    // Wait for the physics to stabilize.
+    await new Promise((resolve): void => {
+      network.on("stabilized", resolve);
+    });
+
+    const positions = network.getPositions();
+    expect(positions[2].x).to.be.greaterThan(0);
+    expect(positions[3].y).to.be.greaterThan(0);
+  });
 });


### PR DESCRIPTION
Allows for the physics simulation to give per-node wind, rather than it being fixed for every node

<img width="618" height="465" alt="Screenshot 2026-05-14 at 7 51 52 pm" src="https://github.com/user-attachments/assets/55c21e2f-a8f2-4adf-ad87-a0cad05cb7c0" />
