### PR TITLE
refactor(dotparser): slightly modernize

### DIFF
--- a/lib/network/dotparser.js
+++ b/lib/network/dotparser.js
@@ -1,49 +1,8 @@
 /* eslint-disable no-prototype-builtins */
 /* eslint-disable no-unused-vars */
-/* eslint-disable no-var */
-
-/**
- * Parse a text source containing data in DOT language into a JSON object.
- * The object contains two lists: one with nodes and one with edges.
- *
- * DOT language reference: http://www.graphviz.org/doc/info/lang.html
- *
- * DOT language attributes: http://graphviz.org/content/attrs
- * @param {string} data     Text containing a graph in DOT-notation
- * @returns {object} graph   An object containing two parameters:
- *                          {Object[]} nodes
- *                          {Object[]} edges
- *
- * -------------------------------------------
- * TODO
- * ====
- *
- * For label handling, this is an incomplete implementation. From docs (quote #3015):
- *
- * > the escape sequences "\n", "\l" and "\r" divide the label into lines, centered,
- * > left-justified, and right-justified, respectively.
- *
- * Source: http://www.graphviz.org/content/attrs#kescString
- *
- * > As another aid for readability, dot allows double-quoted strings to span multiple physical
- * > lines using the standard C convention of a backslash immediately preceding a newline
- * > character
- * > In addition, double-quoted strings can be concatenated using a '+' operator.
- * > As HTML strings can contain newline characters, which are used solely for formatting,
- * > the language does not allow escaped newlines or concatenation operators to be used
- * > within them.
- *
- * - Currently, only '\\n' is handled
- * - Note that text explicitly says 'labels'; the dot parser currently handles escape
- *   sequences in **all** strings.
- */
-export function parseDOT(data) {
-  dot = data;
-  return parseGraph();
-}
 
 // mapping of attributes from DOT (the keys) to vis.js (the values)
-var NODE_ATTR_MAPPING = {
+const NODE_ATTR_MAPPING = {
   fontsize: "font.size",
   fontcolor: "font.color",
   labelfontcolor: "font.color",
@@ -53,12 +12,12 @@ var NODE_ATTR_MAPPING = {
   tooltip: "title",
   labeltooltip: "title",
 };
-var EDGE_ATTR_MAPPING = Object.create(NODE_ATTR_MAPPING);
+const EDGE_ATTR_MAPPING = Object.create(NODE_ATTR_MAPPING);
 EDGE_ATTR_MAPPING.color = "color.color";
 EDGE_ATTR_MAPPING.style = "dashes";
 
 // token types enumeration
-var TOKENTYPE = {
+const TOKENTYPE = {
   NULL: 0,
   DELIMITER: 1,
   IDENTIFIER: 2,
@@ -66,7 +25,7 @@ var TOKENTYPE = {
 };
 
 // map with all delimiters
-var DELIMITERS = {
+const DELIMITERS = {
   "{": true,
   "}": true,
   "[": true,
@@ -79,11 +38,11 @@ var DELIMITERS = {
   "--": true,
 };
 
-var dot = ""; // current dot file
-var index = 0; // current index in dot file
-var c = ""; // current token character in expr
-var token = ""; // current token
-var tokenType = TOKENTYPE.NULL; // type of the token
+let dot = ""; // current dot file
+let index = 0; // current index in dot file
+let c = ""; // current token character in expr
+let token = ""; // current token
+let tokenType = TOKENTYPE.NULL; // type of the token
 
 /**
  * Get the first character from the dot file.
@@ -119,7 +78,7 @@ function nextPreview() {
  * @returns {boolean} isAlphaNumeric
  */
 function isAlphaNumeric(c) {
-  var charCode = c.charCodeAt(0);
+  const charCode = c.charCodeAt(0);
 
   if (charCode < 47) {
     // #.
@@ -157,7 +116,7 @@ function merge(a, b) {
   }
 
   if (b) {
-    for (var name in b) {
+    for (const name in b) {
       if (b.hasOwnProperty(name)) {
         a[name] = b[name];
       }
@@ -170,7 +129,7 @@ function merge(a, b) {
  * Set a value in an object, where the provided parameter name can be a
  * path with nested parameters. For example:
  *
- * var obj = {a: 2};
+ * const obj = {a: 2};
  * setValue(obj, 'b.c', 3);     // obj = {a: 2, b: {c: 3}}
  * @param {object} obj
  * @param {string} path  A parameter name or dot-separated parameter path,
@@ -178,10 +137,10 @@ function merge(a, b) {
  * @param {*} value
  */
 function setValue(obj, path, value) {
-  var keys = path.split(".");
-  var o = obj;
+  const keys = path.split(".");
+  let o = obj;
   while (keys.length) {
-    var key = keys.shift();
+    const key = keys.shift();
     if (keys.length) {
       // this isn't the end point
       if (!o[key]) {
@@ -202,12 +161,12 @@ function setValue(obj, path, value) {
  * @param {object} node
  */
 function addNode(graph, node) {
-  var i, len;
-  var current = null;
+  let i, len;
+  let current = null;
 
   // find root graph (in case of subgraph)
-  var graphs = [graph]; // list with all graphs from current graph to root graph
-  var root = graph;
+  const graphs = [graph]; // list with all graphs from current graph to root graph
+  let root = graph;
   while (root.parent) {
     graphs.push(root.parent);
     root = root.parent;
@@ -236,7 +195,7 @@ function addNode(graph, node) {
 
   // add node to this (sub)graph and all its parent graphs
   for (i = graphs.length - 1; i >= 0; i--) {
-    var g = graphs[i];
+    const g = graphs[i];
 
     if (!g.nodes) {
       g.nodes = [];
@@ -263,7 +222,7 @@ function addEdge(graph, edge) {
   }
   graph.edges.push(edge);
   if (graph.edge) {
-    var attr = merge({}, graph.edge); // clone default attributes
+    const attr = merge({}, graph.edge); // clone default attributes
     edge.attr = merge(attr, edge.attr); // merge attributes
   }
 }
@@ -278,7 +237,7 @@ function addEdge(graph, edge) {
  * @returns {object} edge
  */
 function createEdge(graph, from, to, type, attr) {
-  var edge = {
+  const edge = {
     from: from,
     to: to,
     type: type,
@@ -314,13 +273,14 @@ function getToken() {
     next();
   }
 
+  let isComment;
   do {
-    var isComment = false;
+    isComment = false;
 
     // skip comment
     if (c === "#") {
       // find the previous non-space character
-      var i = index - 1;
+      let i = index - 1;
       while (dot.charAt(i) === " " || dot.charAt(i) === "\t") {
         i--;
       }
@@ -369,7 +329,7 @@ function getToken() {
   }
 
   // check for delimiters consisting of 2 characters
-  var c2 = c + nextPreview();
+  const c2 = c + nextPreview();
   if (DELIMITERS[c2]) {
     tokenType = TOKENTYPE.DELIMITER;
     token = c2;
@@ -446,7 +406,7 @@ function getToken() {
  * @returns {object} graph
  */
 function parseGraph() {
-  var graph = {};
+  const graph = {};
 
   first();
   getToken();
@@ -519,7 +479,7 @@ function parseStatements(graph) {
  */
 function parseStatement(graph) {
   // parse subgraph
-  var subgraph = parseSubgraph(graph);
+  const subgraph = parseSubgraph(graph);
   if (subgraph) {
     // edge statements
     parseEdge(graph, subgraph);
@@ -528,7 +488,7 @@ function parseStatement(graph) {
   }
 
   // parse an attribute statement
-  var attr = parseAttributeStatement(graph);
+  const attr = parseAttributeStatement(graph);
   if (attr) {
     return;
   }
@@ -537,7 +497,7 @@ function parseStatement(graph) {
   if (tokenType != TOKENTYPE.IDENTIFIER) {
     throw newSyntaxError("Identifier expected");
   }
-  var id = token; // id can be a string or a number
+  const id = token; // id can be a string or a number
   getToken();
 
   if (token === "=") {
@@ -560,7 +520,7 @@ function parseStatement(graph) {
  * @returns {object | null} subgraph
  */
 function parseSubgraph(graph) {
-  var subgraph = null;
+  let subgraph = null;
 
   // optional subgraph keyword
   if (token === "subgraph") {
@@ -653,10 +613,10 @@ function parseAttributeStatement(graph) {
  */
 function parseNodeStatement(graph, id) {
   // node statement
-  var node = {
+  const node = {
     id: id,
   };
-  var attr = parseAttributeList();
+  const attr = parseAttributeList();
   if (attr) {
     node.attr = attr;
   }
@@ -673,11 +633,11 @@ function parseNodeStatement(graph, id) {
  */
 function parseEdge(graph, from) {
   while (token === "->" || token === "--") {
-    var to;
-    var type = token;
+    let to;
+    const type = token;
     getToken();
 
-    var subgraph = parseSubgraph(graph);
+    const subgraph = parseSubgraph(graph);
     if (subgraph) {
       to = subgraph;
     } else {
@@ -692,10 +652,10 @@ function parseEdge(graph, from) {
     }
 
     // parse edge attributes
-    var attr = parseAttributeList();
+    const attr = parseAttributeList();
 
     // create edge
-    var edge = createEdge(graph, from, to, type, attr);
+    const edge = createEdge(graph, from, to, type, attr);
     addEdge(graph, edge);
 
     from = to;
@@ -718,11 +678,10 @@ function parseEdge(graph, from) {
  * @returns {object} attr_list  Updated attr_list
  */
 function parseDirAttribute(attr_names, attr_list) {
-  var i;
   if (attr_names.includes("dir")) {
-    var idx = {}; // get index of 'arrows' and 'dir'
+    const idx = {}; // get index of 'arrows' and 'dir'
     idx.arrows = {};
-    for (i = 0; i < attr_list.length; i++) {
+    for (let i = 0; i < attr_list.length; i++) {
       if (attr_list[i].name === "arrows") {
         if (attr_list[i].value.to != null) {
           idx.arrows.to = i;
@@ -737,7 +696,7 @@ function parseDirAttribute(attr_names, attr_list) {
     }
 
     // first, add default arrow shape if it is not assigned to avoid error
-    var dir_type = attr_list[idx.dir].value;
+    const dir_type = attr_list[idx.dir].value;
     if (!attr_names.includes("arrows")) {
       if (dir_type === "both") {
         attr_list.push({
@@ -778,8 +737,8 @@ function parseDirAttribute(attr_names, attr_list) {
       }
     }
 
-    var from_type;
-    var to_type;
+    let from_type;
+    let to_type;
     // update 'arrows' attribute from 'dir'.
     if (dir_type === "both") {
       // both of shapes of 'from' and 'to' are given
@@ -875,7 +834,7 @@ function parseDirAttribute(attr_names, attr_list) {
         },
       };
     } else if (dir_type === "none") {
-      var idx_arrow;
+      let idx_arrow;
       if (idx.arrows.to) {
         idx_arrow = idx.arrows.to;
       } else {
@@ -955,11 +914,11 @@ function parseDirAttribute(attr_names, attr_list) {
  * @returns {object | null} attr
  */
 function parseAttributeList() {
-  var i;
-  var attr = null;
+  let i;
+  let attr = null;
 
   // edge styles of dot and vis
-  var edgeStyles = {
+  const edgeStyles = {
     dashed: true,
     solid: false,
     dotted: [1, 5],
@@ -971,7 +930,7 @@ function parseAttributeList() {
    * Details of arrow shapes are described in
    * http://www.graphviz.org/content/arrow-shapes
    */
-  var arrowTypes = {
+  const arrowTypes = {
     dot: "circle",
     box: "box",
     crow: "crow",
@@ -989,8 +948,8 @@ function parseAttributeList() {
    * later. For instance, both of 'arrowhead' and 'dir' (edge style defined
    * in DOT) make changes to 'arrows' attribute in vis.
    */
-  var attr_list = new Array();
-  var attr_names = new Array(); // used for checking the case.
+  let attr_list = new Array();
+  const attr_names = new Array(); // used for checking the case.
 
   // parse attributes
   while (token === "[") {
@@ -1000,7 +959,7 @@ function parseAttributeList() {
       if (tokenType != TOKENTYPE.IDENTIFIER) {
         throw newSyntaxError("Attribute name expected");
       }
-      var name = token;
+      let name = token;
 
       getToken();
       if (token != "=") {
@@ -1011,14 +970,14 @@ function parseAttributeList() {
       if (tokenType != TOKENTYPE.IDENTIFIER) {
         throw newSyntaxError("Attribute value expected");
       }
-      var value = token;
+      let value = token;
 
       // convert from dot style to vis
       if (name === "style") {
         value = edgeStyles[value];
       }
 
-      var arrowType;
+      let arrowType;
       if (name === "arrowhead") {
         arrowType = arrowTypes[value];
         name = "arrows";
@@ -1056,9 +1015,9 @@ function parseAttributeList() {
    * [1] https://www.graphviz.org/doc/info/attrs.html#h:undir_note
    */
   if (attr_names.includes("dir")) {
-    var idx = {}; // get index of 'arrows' and 'dir'
+    const idx = {}; // get index of 'arrows' and 'dir'
     idx.arrows = {};
-    for (i = 0; i < attr_list.length; i++) {
+    for (let i = 0; i < attr_list.length; i++) {
       if (attr_list[i].name === "arrows") {
         if (attr_list[i].value.to != null) {
           idx.arrows.to = i;
@@ -1073,7 +1032,7 @@ function parseAttributeList() {
     }
 
     // first, add default arrow shape if it is not assigned to avoid error
-    var dir_type = attr_list[idx.dir].value;
+    const dir_type = attr_list[idx.dir].value;
     if (!attr_names.includes("arrows")) {
       if (dir_type === "both") {
         attr_list.push({
@@ -1114,8 +1073,8 @@ function parseAttributeList() {
       }
     }
 
-    var from_type;
-    var to_type;
+    let from_type;
+    let to_type;
     // update 'arrows' attribute from 'dir'.
     if (dir_type === "both") {
       // both of shapes of 'from' and 'to' are given
@@ -1211,7 +1170,7 @@ function parseAttributeList() {
         },
       };
     } else if (dir_type === "none") {
-      var idx_arrow;
+      let idx_arrow;
       if (idx.arrows.to) {
         idx_arrow = idx.arrows.to;
       } else {
@@ -1281,9 +1240,9 @@ function parseAttributeList() {
   }
 
   // parse 'penwidth'
-  var nof_attr_list;
+  let nof_attr_list;
   if (attr_names.includes("penwidth")) {
-    var tmp_attr_list = [];
+    const tmp_attr_list = [];
 
     nof_attr_list = attr_list.length;
     for (i = 0; i < nof_attr_list; i++) {
@@ -1365,13 +1324,13 @@ function forEach2(array1, array2, fn) {
  * @returns {object} Returns the original object, allows for chaining.
  */
 function setProp(object, path, value) {
-  var names = path.split(".");
-  var prop = names.pop();
+  const names = path.split(".");
+  const prop = names.pop();
 
   // traverse over the nested objects
-  var obj = object;
-  for (var i = 0; i < names.length; i++) {
-    var name = names[i];
+  let obj = object;
+  for (let i = 0; i < names.length; i++) {
+    const name = names[i];
     if (!(name in obj)) {
       obj[name] = {};
     }
@@ -1391,11 +1350,11 @@ function setProp(object, path, value) {
  * @returns {object}         Returns an object with vis.js attributes
  */
 function convertAttr(attr, mapping) {
-  var converted = {};
+  const converted = {};
 
-  for (var prop in attr) {
+  for (const prop in attr) {
     if (attr.hasOwnProperty(prop)) {
-      var visProp = mapping[prop];
+      const visProp = mapping[prop];
       if (Array.isArray(visProp)) {
         visProp.forEach(function (visPropI) {
           setProp(converted, visPropI, attr[prop]);
@@ -1419,8 +1378,8 @@ function convertAttr(attr, mapping) {
  */
 export function DOTToGraph(data) {
   // parse the DOT file
-  var dotData = parseDOT(data);
-  var graphData = {
+  const dotData = parseDOT(data);
+  const graphData = {
     nodes: [],
     edges: [],
     options: {},
@@ -1429,7 +1388,7 @@ export function DOTToGraph(data) {
   // copy the nodes
   if (dotData.nodes) {
     dotData.nodes.forEach(function (dotNode) {
-      var graphNode = {
+      const graphNode = {
         id: dotNode.id,
         label: String(dotNode.label || dotNode.id),
       };
@@ -1448,8 +1407,8 @@ export function DOTToGraph(data) {
      * @param {object} dotEdge
      * @returns {object} graphEdge
      */
-    var convertEdge = function (dotEdge) {
-      var graphEdge = {
+    const convertEdge = function (dotEdge) {
+      const graphEdge = {
         from: dotEdge.from,
         to: dotEdge.to,
       };
@@ -1466,7 +1425,7 @@ export function DOTToGraph(data) {
     };
 
     dotData.edges.forEach(function (dotEdge) {
-      var from, to;
+      let from, to;
       if (dotEdge.from instanceof Object) {
         from = dotEdge.from.nodes;
       } else {
@@ -1485,26 +1444,26 @@ export function DOTToGraph(data) {
 
       if (dotEdge.from instanceof Object && dotEdge.from.edges) {
         dotEdge.from.edges.forEach(function (subEdge) {
-          var graphEdge = convertEdge(subEdge);
+          const graphEdge = convertEdge(subEdge);
           graphData.edges.push(graphEdge);
         });
       }
 
       forEach2(from, to, function (from, to) {
-        var subEdge = createEdge(
+        const subEdge = createEdge(
           graphData,
           from.id,
           to.id,
           dotEdge.type,
           dotEdge.attr,
         );
-        var graphEdge = convertEdge(subEdge);
+        const graphEdge = convertEdge(subEdge);
         graphData.edges.push(graphEdge);
       });
 
       if (dotEdge.to instanceof Object && dotEdge.to.edges) {
         dotEdge.to.edges.forEach(function (subEdge) {
-          var graphEdge = convertEdge(subEdge);
+          const graphEdge = convertEdge(subEdge);
           graphData.edges.push(graphEdge);
         });
       }
@@ -1519,6 +1478,45 @@ export function DOTToGraph(data) {
   return graphData;
 }
 
-/* eslint-enable no-var */
+/**
+ * Parse a text source containing data in DOT language into a JSON object.
+ * The object contains two lists: one with nodes and one with edges.
+ *
+ * DOT language reference: http://www.graphviz.org/doc/info/lang.html
+ *
+ * DOT language attributes: http://graphviz.org/content/attrs
+ * @param {string} data     Text containing a graph in DOT-notation
+ * @returns {object} graph   An object containing two parameters:
+ *                          {Object[]} nodes
+ *                          {Object[]} edges
+ *
+ * -------------------------------------------
+ * TODO
+ * ====
+ *
+ * For label handling, this is an incomplete implementation. From docs (quote #3015):
+ *
+ * > the escape sequences "\n", "\l" and "\r" divide the label into lines, centered,
+ * > left-justified, and right-justified, respectively.
+ *
+ * Source: http://www.graphviz.org/content/attrs#kescString
+ *
+ * > As another aid for readability, dot allows double-quoted strings to span multiple physical
+ * > lines using the standard C convention of a backslash immediately preceding a newline
+ * > character
+ * > In addition, double-quoted strings can be concatenated using a '+' operator.
+ * > As HTML strings can contain newline characters, which are used solely for formatting,
+ * > the language does not allow escaped newlines or concatenation operators to be used
+ * > within them.
+ *
+ * - Currently, only '\\n' is handled
+ * - Note that text explicitly says 'labels'; the dot parser currently handles escape
+ *   sequences in **all** strings.
+ */
+export function parseDOT(data) {
+  dot = data;
+  return parseGraph();
+}
+
 /* eslint-enable no-unused-vars */
 /* eslint-enable no-prototype-builtins */

--- a/test/dotparser.test.js
+++ b/test/dotparser.test.js
@@ -1,165 +1,142 @@
 import { expect } from "chai";
-import fs from "fs";
+import { readFile } from "node:fs/promises";
+import { URL } from "node:url";
 import { parseDOT } from "../lib/network/dotparser.js";
 
 describe("dotparser", function () {
-  it("should parse a DOT file into JSON", function () {
-    fs.readFile("test/dot.txt", function (err, data) {
-      data = String(data);
+  it("should parse a DOT file into JSON", async function () {
+    const fixtureUrl = new URL("./dot.txt", import.meta.url);
+    const data = await readFile(fixtureUrl, "utf8");
 
-      const graph = parseDOT(data);
+    const graph = parseDOT(data);
 
-      expect(graph).to.deep.equal({
-        type: "digraph",
-        id: "test_graph",
-        rankdir: "LR",
-        size: "8,5",
-        font: "arial",
-        nodes: [
-          {
-            id: "node1",
-            attr: {
-              shape: "doublecircle",
-            },
+    expect(graph).to.deep.equal({
+      type: "digraph",
+      id: "test_graph",
+      rankdir: "LR",
+      size: "8,5",
+      font: "arial",
+      nodes: [
+        {
+          id: "node1",
+          attr: {
+            shape: "doublecircle",
           },
-          {
-            id: "node2",
-            attr: {
-              shape: "doublecircle",
-            },
+        },
+        {
+          id: "node2",
+          attr: {
+            shape: "doublecircle",
           },
-          {
-            id: "node3",
-            attr: {
-              shape: "doublecircle",
-            },
+        },
+        {
+          id: "node3",
+          attr: {
+            shape: "doublecircle",
           },
-          {
-            id: "node4",
-            attr: {
-              shape: "diamond",
-              color: "red",
-            },
+        },
+        {
+          id: "node4",
+          attr: {
+            shape: "diamond",
+            color: "red",
           },
-          {
-            id: "node5",
-            attr: {
-              shape: "square",
-              color: "blue",
-              width: 3,
-            },
+        },
+        {
+          id: "node5",
+          attr: {
+            shape: "square",
+            color: "blue",
+            width: 3,
           },
-          {
-            id: 6,
-            attr: {
-              shape: "circle",
-            },
+        },
+        {
+          id: 6,
+          attr: {
+            shape: "circle",
           },
-          {
-            id: "A",
-            attr: {
-              shape: "circle",
-            },
+        },
+        {
+          id: "A",
+          attr: {
+            shape: "circle",
           },
-          {
-            id: "B",
-            attr: {
-              shape: "circle",
-            },
+        },
+        {
+          id: "B",
+          attr: {
+            shape: "circle",
           },
-          {
-            id: "C",
-            attr: {
-              shape: "circle",
-            },
+        },
+        {
+          id: "C",
+          attr: {
+            shape: "circle",
           },
-        ],
-        edges: [
-          {
-            from: "node1",
-            to: "node1",
-            type: "->",
-            attr: {
-              length: 170,
-              fontSize: 12,
-              label: "a",
-            },
+        },
+      ],
+      edges: [
+        {
+          from: "node1",
+          to: "node1",
+          type: "->",
+          attr: {
+            length: 170,
+            fontSize: 12,
+            label: "a",
           },
-          {
-            from: "node2",
-            to: "node3",
-            type: "->",
-            attr: {
-              length: 170,
-              fontSize: 12,
-              label: "b",
-            },
+        },
+        {
+          from: "node2",
+          to: "node3",
+          type: "->",
+          attr: {
+            length: 170,
+            fontSize: 12,
+            label: "b",
           },
-          {
-            from: "node1",
-            to: "node4",
-            type: "--",
-            attr: {
-              length: 170,
-              fontSize: 12,
-              label: "c",
-            },
+        },
+        {
+          from: "node1",
+          to: "node4",
+          type: "--",
+          attr: {
+            length: 170,
+            fontSize: 12,
+            label: "c",
           },
-          {
-            from: "node3",
-            to: "node4",
-            type: "->",
-            attr: {
-              length: 170,
-              fontSize: 12,
-              label: "d",
-            },
+        },
+        {
+          from: "node3",
+          to: "node4",
+          type: "->",
+          attr: {
+            length: 170,
+            fontSize: 12,
+            label: "d",
           },
-          {
-            from: "node4",
-            to: "node5",
-            type: "->",
-            attr: {
-              length: 170,
-              fontSize: 12,
-            },
+        },
+        {
+          from: "node4",
+          to: "node5",
+          type: "->",
+          attr: {
+            length: 170,
+            fontSize: 12,
           },
-          {
-            from: "node5",
-            to: 6,
-            type: "->",
-            attr: {
-              length: 170,
-              fontSize: 12,
-            },
+        },
+        {
+          from: "node5",
+          to: 6,
+          type: "->",
+          attr: {
+            length: 170,
+            fontSize: 12,
           },
-          {
-            from: "A",
-            to: {
-              nodes: [
-                {
-                  id: "B",
-                  attr: {
-                    shape: "circle",
-                  },
-                },
-                {
-                  id: "C",
-                  attr: {
-                    shape: "circle",
-                  },
-                },
-              ],
-            },
-            type: "->",
-            attr: {
-              length: 170,
-              fontSize: 12,
-            },
-          },
-        ],
-        subgraphs: [
-          {
+        },
+        {
+          from: "A",
+          to: {
             nodes: [
               {
                 id: "B",
@@ -175,8 +152,31 @@ describe("dotparser", function () {
               },
             ],
           },
-        ],
-      });
+          type: "->",
+          attr: {
+            length: 170,
+            fontSize: 12,
+          },
+        },
+      ],
+      subgraphs: [
+        {
+          nodes: [
+            {
+              id: "B",
+              attr: {
+                shape: "circle",
+              },
+            },
+            {
+              id: "C",
+              attr: {
+                shape: "circle",
+              },
+            },
+          ],
+        },
+      ],
     });
   });
 
@@ -184,9 +184,7 @@ describe("dotparser", function () {
    * DOT-format examples taken from #3015
    */
   it("properly handles newline escape sequences in strings", function () {
-    let data = 'dinetwork {1 [label="new\nline"];}';
-
-    data = String(data);
+    const data = 'dinetwork {1 [label="new\nline"];}';
 
     const graph = parseDOT(data);
 
@@ -203,7 +201,7 @@ describe("dotparser", function () {
     });
 
     // Note the double backslashes
-    let data2 =
+    const data2 =
       "digraph {" +
       "\n" +
       '	3 [color="#0d2b7c", label="query:1230:add_q\\n0.005283\\n6.83%\\n(0.0001)\\n(0.13%)\\n17×"];' +
@@ -213,8 +211,6 @@ describe("dotparser", function () {
       '	5 [color="#0d1976", label="urlresolvers:537:reverse\\n0.00219\\n2.83%\\n(0.000193)\\n(0.25%)\\n29×"];' +
       "\n" +
       "}";
-
-    data2 = String(data2);
 
     const graph2 = parseDOT(data2);
     //console.log(JSON.stringify(graph, null, 2));


### PR DESCRIPTION
refactor(dotparser): migrate from var to const+let, remove no-var exception

test(dotparser): synchronize async fixture read with Mocha

The fixture-loading test invoked callback-based fs.readFile inside a
synchronous Mocha test, so the test body returned before assertions ran
and any AssertionError was silently swallowed. Convert the test to async
and await readFile from node:fs/promises, resolving the fixture via a
module-relative URL so it does not depend on the runner's cwd. Also drop
dead String() coercions and let→const in the sibling test.