### PR TITLE
fix(node.icon): Allow Node.icon to inherit Node.size

### DIFF
--- a/docs/network/nodes.html
+++ b/docs/network/nodes.html
@@ -1111,7 +1111,10 @@ function({ ctx, x, y, state: { selected, hover }, style }) {
           <td class="indent">icon.size</td>
           <td>Number</td>
           <td><code>50</code></td>
-          <td>The size of the icon.</td>
+          <td>
+            The size of the icon. (will inherit <code>size</code> if
+            <code>undefined</code>)
+          </td>
         </tr>
         <tr parent="icon" class="hidden">
           <td class="indent">icon.color</td>

--- a/docs/network/nodes.html
+++ b/docs/network/nodes.html
@@ -1111,9 +1111,22 @@ function({ ctx, x, y, state: { selected, hover }, style }) {
           <td class="indent">icon.size</td>
           <td>Number</td>
           <td><code>50</code></td>
+          <td>The size of the icon.</td>
+        </tr>
+        <tr parent="icon" class="hidden">
+          <td class="indent">icon.inheritSize</td>
+          <td>Boolean</td>
+          <td><code>false</code></td>
           <td>
-            The size of the icon. (will inherit <code>size</code> if
-            <code>undefined</code>)
+            When <code>true</code>, inherit <code>size</code> from
+            <code>node.size</code>. Takes precedence over
+            <code>icon.size</code>. <br /><i
+              >Note: This flag exists to preserve the original behavior of
+              icons. If using groups to set icons, you may want to set this to
+              <code>true</code>
+              so you can drive icon size without overwriting the group icon
+              object.
+            </i>
           </td>
         </tr>
         <tr parent="icon" class="hidden">

--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -85,7 +85,7 @@ class NodesHandler {
       icon: {
         face: "FontAwesome", //'FontAwesome',
         code: undefined, //'\uf007',
-        size: 50, //50,
+        size: undefined, //set to 50 in NodeBase to allow inheriting Node.size,
         color: "#2B7CE9", //'#aa00ff'
       },
       image: undefined, // --> URL
@@ -142,7 +142,7 @@ class NodesHandler {
         useBorderWithImage: false, // only for image shape
         coordinateOrigin: "center", // only for image and circularImage shapes
       },
-      size: 25,
+      size: undefined, // set to 25 in NodeBase to allow icon to inherit size,
       title: undefined,
       value: undefined,
       x: undefined,

--- a/lib/network/modules/components/nodes/util/NodeBase.js
+++ b/lib/network/modules/components/nodes/util/NodeBase.js
@@ -26,6 +26,10 @@ class NodeBase {
    * @param {object} options
    */
   setOptions(options) {
+    if (options.icon !== undefined && options.icon.size === undefined) {
+      options.icon.size = options.size || 50;
+    }
+    options.size = options.size || 25;
     this.options = options;
   }
 

--- a/lib/network/modules/components/nodes/util/NodeBase.js
+++ b/lib/network/modules/components/nodes/util/NodeBase.js
@@ -26,8 +26,12 @@ class NodeBase {
    * @param {object} options
    */
   setOptions(options) {
-    if (options.icon !== undefined && options.icon.size === undefined) {
-      options.icon.size = options.size || 50;
+    if (options.icon) {
+      if (options.icon.inheritSize) {
+        options.icon.size = options.size || 50;
+      } else {
+        options.icon.size = options.icon.size || 50;
+      }
     }
     options.size = options.size || 25;
     this.options = options;

--- a/lib/network/options.ts
+++ b/lib/network/options.ts
@@ -121,6 +121,7 @@ const nodeOptions: OptionsConfig = {
     face: { string },
     code: { string }, //'\uf007',
     size: { number }, //50,
+    inheritSize: { boolean: bool },
     color: { string },
     weight: { string, number },
     __type__: { object },

--- a/types/network/Network.d.ts
+++ b/types/network/Network.d.ts
@@ -923,6 +923,7 @@ export interface NodeOptions {
     size?: number,  // 50,
     color?: string,
     weight?: number | string,
+    inheritSize?: boolean,
   };
 
   image?: string | Image;


### PR DESCRIPTION
*No AI used at any stage of this PR*

Change option resolution order for Node to allow node icon size to inherit from node size

I tried to keep the resolution simple. Since `icon.size` is the only shape that uses a seperate `size` property, I had to unset the defaults in `NodesHandler` for both `size` and `icon.size`.

These options are resolved in `NodeBase.setOptions` now.

Old Icon Size Resolution:

`<nodeobj>.icon.size -> <groupobj>.icon.size -> <network.nodes>.icon.size`

New Icon Size Resolution:

```
(node->group->network.nodes).icon.size
--then--
(node->group->network.nodes).size
--then--
50
```

I'm not sure if it's better to have the size be inherited this way though:
```
node.icon.size -> node.size
--then--
group.icon.size -> group.size
--then--
network.icon.size -> network.size
--then--
50 
```

If the second option is more logical I will gladly ammend this PR to do it that way. I just figured that `icon.size` being directly set at any point should probably supercede the `size` fallbacks to prevent issues with existing setups.

This might also cause breaking changes if someone is setting `size` and leaving it set on an icon node because they saw no change. The fix would be to either remove the `size` key from the node or to set `icon.size` at any level of the config.

resolves #385
