### PR TITLE
fix(types): add .d.ts files for CSS

### DIFF
--- a/__snapshots__/test/package.test.ts.js
+++ b/__snapshots__/test/package.test.ts.js
@@ -151,6 +151,9 @@ exports['Package Exported files 1'] = {
     "declarations/network/modules/components/edges/util/types.d.ts.map": {
       empty: false
     },
+    "declarations/network/modules/components/NavigationHandler.css.d.ts": {
+      empty: false
+    },
     "declarations/network/modules/components/nodes/util/shapes.d.ts": {
       empty: false
     },
@@ -161,6 +164,9 @@ exports['Package Exported files 1'] = {
       empty: false
     },
     "declarations/network/modules/layout-engine/index.d.ts.map": {
+      empty: false
+    },
+    "declarations/network/modules/ManipulationSystem.css.d.ts": {
       empty: false
     },
     "declarations/network/modules/selection/index.d.ts": {
@@ -382,6 +388,9 @@ exports['Package Exported files 1'] = {
     "dist/types/network/modules/components/edges/util/types.d.ts.map": {
       empty: false
     },
+    "dist/types/network/modules/components/NavigationHandler.css.d.ts": {
+      empty: false
+    },
     "dist/types/network/modules/components/nodes/util/shapes.d.ts": {
       empty: false
     },
@@ -392,6 +401,9 @@ exports['Package Exported files 1'] = {
       empty: false
     },
     "dist/types/network/modules/layout-engine/index.d.ts.map": {
+      empty: false
+    },
+    "dist/types/network/modules/ManipulationSystem.css.d.ts": {
       empty: false
     },
     "dist/types/network/modules/selection/index.d.ts": {

--- a/types/network/modules/ManipulationSystem.css.d.ts
+++ b/types/network/modules/ManipulationSystem.css.d.ts
@@ -1,0 +1,2 @@
+// oxlint-disable-next-line unicorn/require-module-specifiers -- This is a shim for CSS files that are imported for side-effects only, this rule doesn't apply here.
+export {};

--- a/types/network/modules/components/NavigationHandler.css.d.ts
+++ b/types/network/modules/components/NavigationHandler.css.d.ts
@@ -1,0 +1,2 @@
+// oxlint-disable-next-line unicorn/require-module-specifiers -- This is a shim for CSS files that are imported for side-effects only, this rule doesn't apply here.
+export {};


### PR DESCRIPTION
Add stub .d.ts files for side-effect CSS imports to allow the emitted declarations to type check and therefore allow people to us this without `skipLibCheck: true`.

Fixes #2517